### PR TITLE
Add Twilight Realms browser-only demo

### DIFF
--- a/data/attributes.json
+++ b/data/attributes.json
@@ -1,0 +1,12 @@
+{
+  "base": {
+    "str": 5,
+    "dex": 5,
+    "int": 5,
+    "wis": 5,
+    "spi": 5,
+    "vit": 5,
+    "points": 30,
+    "maxLevel": 60
+  }
+}

--- a/data/classes.json
+++ b/data/classes.json
@@ -1,0 +1,42 @@
+{
+  "warrior": {
+    "name": "Warrior",
+    "starterAbilities": ["slash", "block"]
+  },
+  "paladin": {
+    "name": "Paladin",
+    "starterAbilities": ["smite", "heal"]
+  },
+  "cleric": {
+    "name": "Cleric",
+    "starterAbilities": ["heal", "bless"]
+  },
+  "mage": {
+    "name": "Mage",
+    "starterAbilities": ["fireball", "frostbolt"]
+  },
+  "rogue": {
+    "name": "Rogue",
+    "starterAbilities": ["backstab", "stealth"]
+  },
+  "ranger": {
+    "name": "Ranger",
+    "starterAbilities": ["shoot", "track"]
+  },
+  "druid": {
+    "name": "Druid",
+    "starterAbilities": ["entangle", "regrowth"]
+  },
+  "necromancer": {
+    "name": "Necromancer",
+    "starterAbilities": ["drain", "raise_dead"]
+  },
+  "shaman": {
+    "name": "Shaman",
+    "starterAbilities": ["lightning", "totem"]
+  },
+  "bard": {
+    "name": "Bard",
+    "starterAbilities": ["song_of_valor", "lullaby"]
+  }
+}

--- a/data/deities.json
+++ b/data/deities.json
@@ -1,0 +1,14 @@
+{
+  "solara": {
+    "name": "Solara",
+    "domain": "Light",
+    "faction": "luminara",
+    "description": "Goddess of the radiant sun."
+  },
+  "nocturn": {
+    "name": "Nocturn",
+    "domain": "Shadow",
+    "faction": "umbra",
+    "description": "Lord of the endless night."
+  }
+}

--- a/data/items.json
+++ b/data/items.json
@@ -1,0 +1,69 @@
+{
+  "rusty_sword": {
+    "name": "Rusty Sword",
+    "level": 1,
+    "damage": 4,
+    "slot": "weapon",
+    "description": "An old sword with a dull blade."
+  },
+  "leather_armor": {
+    "name": "Leather Armor",
+    "level": 1,
+    "armor": 2,
+    "slot": "chest",
+    "description": "Provides minimal protection."
+  },
+  "healing_potion": {
+    "name": "Healing Potion",
+    "level": 1,
+    "heal": 20,
+    "description": "Restores a small amount of HP."
+  },
+  "mana_potion": {
+    "name": "Mana Potion",
+    "level": 1,
+    "mana": 20,
+    "description": "Restores a small amount of MP."
+  },
+  "wooden_shield": {
+    "name": "Wooden Shield",
+    "level": 1,
+    "armor": 1,
+    "slot": "offhand",
+    "description": "A basic wooden shield."
+  },
+  "hunter_bow": {
+    "name": "Hunter Bow",
+    "level": 1,
+    "damage": 3,
+    "slot": "weapon",
+    "description": "Simple bow favored by rangers."
+  },
+  "druid_staff": {
+    "name": "Druid Staff",
+    "level": 1,
+    "damage": 2,
+    "slot": "weapon",
+    "description": "Carved from an ancient tree."
+  },
+  "shadow_dagger": {
+    "name": "Shadow Dagger",
+    "level": 1,
+    "damage": 5,
+    "slot": "weapon",
+    "description": "A blade that seems to drink the light."
+  },
+  "bard_lute": {
+    "name": "Bard's Lute",
+    "level": 1,
+    "damage": 1,
+    "slot": "weapon",
+    "description": "Plays enchanting melodies."
+  },
+  "torch": {
+    "name": "Torch",
+    "level": 1,
+    "slot": "offhand",
+    "description": "Lights the way in dark places."
+  }
+}

--- a/data/loader.js
+++ b/data/loader.js
@@ -1,0 +1,25 @@
+export const loader = {
+  data: {},
+  async init() {
+    const files = [
+      'attributes',
+      'races',
+      'classes',
+      'deities',
+      'items',
+      'spells',
+      'quests',
+      'locations',
+      'mobs'
+    ];
+    await Promise.all(
+      files.map(async (name) => {
+        const res = await fetch(`data/${name}.json`);
+        this.data[name] = await res.json();
+      })
+    );
+  },
+  get(type, id) {
+    return this.data[type]?.[id];
+  }
+};

--- a/data/locations.json
+++ b/data/locations.json
@@ -1,0 +1,87 @@
+{
+  "gearhaven_plaza": {
+    "name": "Cogwheel Plaza",
+    "faction": "luminara",
+    "description": "Steam hisses from pipes and gears grind beneath your feet.",
+    "exits": [
+      "n",
+      "e",
+      "s"
+    ],
+    "links": {
+      "n": "gearhaven_workshop",
+      "e": "neutral_crossroads",
+      "s": "shadowfen_camp"
+    },
+    "npcs": [
+      "thaldo_tinkerer"
+    ],
+    "spawns": [
+      "rogue_clockwork"
+    ]
+  },
+  "gearhaven_workshop": {
+    "name": "Gearhaven Workshop",
+    "faction": "luminara",
+    "description": "Inventors toil with strange contraptions here.",
+    "exits": [
+      "s"
+    ],
+    "links": {
+      "s": "gearhaven_plaza"
+    },
+    "npcs": [
+      "thaldo_tinkerer"
+    ],
+    "spawns": []
+  },
+  "shadowfen_camp": {
+    "name": "Shadowfen Camp",
+    "faction": "umbra",
+    "description": "A dark encampment surrounded by murky waters.",
+    "exits": [
+      "n",
+      "e"
+    ],
+    "links": {
+      "n": "gearhaven_plaza",
+      "e": "shadowfen_bog"
+    },
+    "npcs": [
+      "bog_hunter"
+    ],
+    "spawns": [
+      "goblin_raider"
+    ]
+  },
+  "shadowfen_bog": {
+    "name": "Shadowfen Bog",
+    "faction": "umbra",
+    "description": "Thick mist blankets the soggy ground.",
+    "exits": [
+      "w"
+    ],
+    "links": {
+      "w": "shadowfen_camp"
+    },
+    "npcs": [],
+    "spawns": [
+      "bog_creeper"
+    ]
+  },
+  "neutral_crossroads": {
+    "name": "Crossroads",
+    "faction": "neutral",
+    "description": "A meeting point of paths leading to many adventures.",
+    "exits": [
+      "w"
+    ],
+    "links": {
+      "w": "gearhaven_plaza"
+    },
+    "npcs": [
+      "ranger_npc"
+    ],
+    "spawns": []
+  }
+}

--- a/data/mobs.json
+++ b/data/mobs.json
@@ -1,0 +1,23 @@
+{
+  "rogue_clockwork": {
+    "name": "Rogue Clockwork",
+    "level": 2,
+    "hp": 30,
+    "damage": 4,
+    "description": "A malfunctioning automaton covered in rust."
+  },
+  "bog_creeper": {
+    "name": "Bog Creeper",
+    "level": 3,
+    "hp": 40,
+    "damage": 5,
+    "description": "Slimy creature lurking in the bog."
+  },
+  "goblin_raider": {
+    "name": "Goblin Raider",
+    "level": 2,
+    "hp": 25,
+    "damage": 3,
+    "description": "Sneaky goblin looking for trouble."
+  }
+}

--- a/data/quests.json
+++ b/data/quests.json
@@ -1,0 +1,77 @@
+{
+  "fix_the_pipes": {
+    "name": "Fix the Pipes",
+    "giver": "thaldo_tinkerer",
+    "description": "Collect 3 pipe parts from rogue clockworks.",
+    "objective": {
+      "item": "pipe_part",
+      "count": 3
+    },
+    "reward": {
+      "xp": 100,
+      "item": "healing_potion"
+    }
+  },
+  "clear_the_bog": {
+    "name": "Clear the Bog",
+    "giver": "bog_hunter",
+    "description": "Slay 2 bog creepers in Shadowfen.",
+    "objective": {
+      "kill": "bog_creeper",
+      "count": 2
+    },
+    "reward": {
+      "xp": 120,
+      "item": "mana_potion"
+    }
+  },
+  "lost_lute": {
+    "name": "Lost Lute",
+    "giver": "bard_npc",
+    "description": "Retrieve the bard's lost lute from goblin raiders.",
+    "objective": {
+      "item": "bard_lute",
+      "count": 1
+    },
+    "reward": {
+      "xp": 150,
+      "item": "bard_lute"
+    }
+  },
+  "gather_herbs": {
+    "name": "Gather Herbs",
+    "giver": "druid_npc",
+    "description": "Collect 5 healing herbs around Gearhaven.",
+    "objective": {
+      "item": "healing_herb",
+      "count": 5
+    },
+    "reward": {
+      "xp": 80,
+      "item": "regrowth_scroll"
+    }
+  },
+  "scout_camp": {
+    "name": "Scout the Camp",
+    "giver": "ranger_npc",
+    "description": "Report the strength of the goblin camp.",
+    "objective": {
+      "location": "goblin_camp"
+    },
+    "reward": {
+      "xp": 70
+    }
+  },
+  "welcome_to_realm": {
+    "name": "Welcome to Twilight Realms",
+    "giver": "thaldo_tinkerer",
+    "description": "Speak with Thaldo to learn the basics.",
+    "objective": {
+      "talk": "thaldo_tinkerer"
+    },
+    "reward": {
+      "xp": 50,
+      "item": "rusty_sword"
+    }
+  }
+}

--- a/data/races.json
+++ b/data/races.json
@@ -1,0 +1,47 @@
+{
+  "human": {
+    "name": "Human",
+    "faction": "luminara",
+    "startLocation": "gearhaven_plaza"
+  },
+  "high_elf": {
+    "name": "High Elf",
+    "faction": "luminara",
+    "startLocation": "gearhaven_plaza"
+  },
+  "dwarf": {
+    "name": "Dwarf",
+    "faction": "luminara",
+    "startLocation": "gearhaven_plaza"
+  },
+  "gnome": {
+    "name": "Gnome",
+    "faction": "luminara",
+    "startLocation": "gearhaven_plaza"
+  },
+  "orc": {
+    "name": "Orc",
+    "faction": "umbra",
+    "startLocation": "shadowfen_camp"
+  },
+  "dark_elf": {
+    "name": "Dark Elf",
+    "faction": "umbra",
+    "startLocation": "shadowfen_camp"
+  },
+  "troll": {
+    "name": "Troll",
+    "faction": "umbra",
+    "startLocation": "shadowfen_camp"
+  },
+  "undead": {
+    "name": "Undead",
+    "faction": "umbra",
+    "startLocation": "shadowfen_camp"
+  },
+  "goblin": {
+    "name": "Goblin",
+    "faction": "umbra",
+    "startLocation": "shadowfen_camp"
+  }
+}

--- a/data/spells.json
+++ b/data/spells.json
@@ -1,0 +1,107 @@
+{
+  "slash": {
+    "name": "Slash",
+    "level": 1,
+    "damage": 3,
+    "description": "A quick melee attack."
+  },
+  "block": {
+    "name": "Block",
+    "level": 1,
+    "description": "Raise shield to reduce damage."
+  },
+  "smite": {
+    "name": "Smite",
+    "level": 1,
+    "damage": 4,
+    "description": "Holy strike versus foes."
+  },
+  "heal": {
+    "name": "Heal",
+    "level": 1,
+    "heal": 10,
+    "description": "Restore a small amount of HP."
+  },
+  "bless": {
+    "name": "Bless",
+    "level": 1,
+    "description": "Increase allies' attack briefly."
+  },
+  "fireball": {
+    "name": "Fireball",
+    "level": 1,
+    "damage": 6,
+    "description": "Hurl a ball of fire."
+  },
+  "frostbolt": {
+    "name": "Frostbolt",
+    "level": 1,
+    "damage": 5,
+    "description": "Chill target with frost."
+  },
+  "backstab": {
+    "name": "Backstab",
+    "level": 1,
+    "damage": 7,
+    "description": "Deal high damage from stealth."
+  },
+  "stealth": {
+    "name": "Stealth",
+    "level": 1,
+    "description": "Vanish from sight."
+  },
+  "shoot": {
+    "name": "Shoot",
+    "level": 1,
+    "damage": 4,
+    "description": "Fire an arrow from your bow."
+  },
+  "track": {
+    "name": "Track",
+    "level": 1,
+    "description": "Reveal nearby creatures."
+  },
+  "entangle": {
+    "name": "Entangle",
+    "level": 1,
+    "description": "Roots the target in place."
+  },
+  "regrowth": {
+    "name": "Regrowth",
+    "level": 1,
+    "heal": 8,
+    "description": "Gradually heals over time."
+  },
+  "drain": {
+    "name": "Drain",
+    "level": 1,
+    "damage": 4,
+    "description": "Steal life from target."
+  },
+  "raise_dead": {
+    "name": "Raise Dead",
+    "level": 1,
+    "description": "Summon an undead minion."
+  },
+  "lightning": {
+    "name": "Lightning",
+    "level": 1,
+    "damage": 5,
+    "description": "Strike a foe with lightning."
+  },
+  "totem": {
+    "name": "Totem",
+    "level": 1,
+    "description": "Place a supportive totem."
+  },
+  "song_of_valor": {
+    "name": "Song of Valor",
+    "level": 1,
+    "description": "Buff allies with inspiring tune."
+  },
+  "lullaby": {
+    "name": "Lullaby",
+    "level": 1,
+    "description": "Attempt to put enemies to sleep."
+  }
+}

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,0 +1,13 @@
+import js from '@eslint/js';
+export default [
+  js.configs.recommended,
+  {
+    files: ['*.js', 'data/loader.js'],
+    languageOptions: {
+      ecmaVersion: 2021,
+      sourceType: 'module',
+      globals: { document: 'readonly', window: 'readonly' , fetch: 'readonly', location: 'readonly', setInterval: 'readonly', clearInterval: 'readonly' }
+    },
+    rules: {}
+  }
+];

--- a/main.js
+++ b/main.js
@@ -1,0 +1,155 @@
+import { loader } from './data/loader.js';
+import { ws } from './websocket-stub.js';
+
+const game = {
+  player: null,
+  target: null,
+  combatTimer: 0
+};
+
+function rand(max) {
+  return Math.floor(Math.random() * max) + 1;
+}
+
+function updateHUD() {
+  const p = game.player;
+  document.getElementById('status').textContent =
+    `HP: ${p.hp}/${p.maxHp}  MP: ${p.mp}/${p.maxMp}`;
+  document.getElementById('target').textContent =
+    game.target ? `Target: ${game.target.name} (${game.target.hp}hp)` : 'Target: —';
+  document.getElementById('party').textContent =
+    `Party: ${p.party.join(', ') || '—'}`;
+}
+
+function addLog(txt) {
+  const div = document.createElement('div');
+  div.textContent = txt;
+  document.getElementById('log').append(div);
+  div.scrollIntoView();
+}
+
+function renderRoom(loc) {
+  const log = document.getElementById('log');
+  log.innerHTML = `
+    <h2 class="text-lg font-bold">${loc.name}</h2>
+    <p>${loc.description}</p>
+    <p><strong>Exits:</strong> ${loc.exits.join(', ')}</p>
+    <p><strong>NPCs:</strong> ${loc.npcs.join(', ') || 'None'}</p>
+    <p><strong>Mobs:</strong> ${loc.spawns.join(', ') || 'None'}</p>
+  `;
+}
+
+function enterRoom(id) {
+  const loc = loader.data.locations[id];
+  if (!loc) return;
+  game.player.location = id;
+  location.hash = id;
+  renderRoom(loc);
+  updateHUD();
+}
+
+function getWeaponDamage() {
+  const w = game.player.equipped.weapon;
+  return loader.data.items[w]?.damage || 1;
+}
+
+function attackRound() {
+  const player = game.player;
+  const mob = game.target;
+  if (!mob) return;
+  const pdmg = rand(getWeaponDamage()) + player.stats.str;
+  mob.hp -= pdmg;
+  addLog(`You hit ${mob.name} for ${pdmg}.`);
+  if (mob.hp <= 0) {
+    addLog(`${mob.name} dies.`);
+    clearInterval(game.combatTimer);
+    game.target = null;
+    updateHUD();
+    return;
+  }
+  const mdmg = rand(mob.damage);
+  player.hp -= mdmg;
+  addLog(`${mob.name} hits you for ${mdmg}.`);
+  if (player.hp <= 0) {
+    addLog('You have been slain!');
+    clearInterval(game.combatTimer);
+    game.target = null;
+  }
+  updateHUD();
+}
+
+function startCombat(mobId) {
+  game.target = { ...loader.data.mobs[mobId] };
+  clearInterval(game.combatTimer);
+  game.combatTimer = setInterval(attackRound, 2000);
+  updateHUD();
+}
+
+function castSpell(id) {
+  const spell = loader.data.spells[id];
+  if (!spell) return;
+  addLog(`You cast ${spell.name}.`);
+}
+
+function buildHotbar() {
+  const bar = document.getElementById('hotbar');
+  const abil = loader.data.classes[game.player.class].starterAbilities;
+  bar.innerHTML = '';
+  abil.slice(0, 10).forEach((id) => {
+    const btn = document.createElement('button');
+    btn.className = 'btn text-xs';
+    btn.textContent = loader.data.spells[id].name;
+    btn.onclick = () => castSpell(id);
+    bar.append(btn);
+  });
+}
+
+function handleInput(text) {
+  const cmd = text.trim();
+  if (['n', 's', 'e', 'w'].includes(cmd)) {
+    const dest = loader.data.locations[game.player.location].links[cmd];
+    if (dest) enterRoom(dest);
+  } else if (cmd.startsWith('/attack')) {
+    const mob = loader.data.locations[game.player.location].spawns[0];
+    if (mob) startCombat(mob);
+  } else if (cmd) {
+    ws.send('chat', { channel: 'say', msg: `${game.player.name}: ${cmd}` });
+  }
+}
+
+function bindUI() {
+  document.getElementById('send').onclick = () => {
+    const inp = document.getElementById('cmd');
+    handleInput(inp.value);
+    inp.value = '';
+  };
+  document.getElementById('cmd').addEventListener('keydown', (e) => {
+    if (e.key === 'Enter') document.getElementById('send').click();
+  });
+  ws.on('chat', (m) => addLog(`[${m.channel}] ${m.msg}`));
+}
+
+export async function init() {
+  await loader.init();
+  game.player = {
+    name: 'Hero',
+    class: 'warrior',
+    race: 'human',
+    stats: { str: 10, dex: 8, int: 5, wis: 5, spi: 5, vit: 10 },
+    hp: 50,
+    maxHp: 50,
+    mp: 20,
+    maxMp: 20,
+    location: loader.data.races.human.startLocation,
+    inventory: ['rusty_sword', 'healing_potion'],
+    equipped: { weapon: 'rusty_sword' },
+    activeQuests: ['welcome_to_realm'],
+    party: []
+  };
+  bindUI();
+  buildHotbar();
+  const start = location.hash.slice(1) || game.player.location;
+  enterRoom(start);
+}
+
+init();

--- a/package.json
+++ b/package.json
@@ -1,0 +1,5 @@
+{
+  "devDependencies": {
+    "@eslint/js": "^9.32.0"
+  }
+}


### PR DESCRIPTION
## Summary
- implement a simple static prototype for **Twilight Realms**
- create JSON-based data sets for races, classes, items, spells, quests, locations, mobs and attributes
- add generic loader and basic game engine
- include a websocket stub and minimal styles
- provide ESLint config for `eslint:recommended`

## Testing
- `npx eslint *.js data/loader.js`
- `npx serve . -l 5000 -s -n` *(fails: needs interactive prompt)*

------
https://chatgpt.com/codex/tasks/task_e_68869dfcea30832f880328ce553c82ee