### PR TITLE
Add clickable NPC tracker

### DIFF
--- a/data/loader.js
+++ b/data/loader.js
@@ -10,7 +10,8 @@ export const loader = {
       'spells',
       'quests',
       'locations',
-      'mobs'
+      'mobs',
+      'npcs'
     ];
     await Promise.all(
       files.map(async (name) => {

--- a/data/locations.json
+++ b/data/locations.json
@@ -2,7 +2,7 @@
   "gearhaven_plaza": {
     "name": "Cogwheel Plaza",
     "faction": "luminara",
-    "description": "Steam hisses from pipes and gears grind beneath your feet.",
+    "description": "Steam hisses from pipes and gears grind beneath your feet. Merchants shout over the clatter while travelers mingle in the plaza.",
     "exits": [
       "n",
       "e",
@@ -14,7 +14,13 @@
       "s": "shadowfen_camp"
     },
     "npcs": [
-      "thaldo_tinkerer"
+      "thaldo_tinkerer",
+      "gilda_crafter",
+      "rogar_trainer",
+      "belena_trainer",
+      "bard_npc",
+      "druid_npc",
+      "joran_barkeep"
     ],
     "spawns": [
       "rogue_clockwork"
@@ -23,7 +29,7 @@
   "gearhaven_workshop": {
     "name": "Gearhaven Workshop",
     "faction": "luminara",
-    "description": "Inventors toil with strange contraptions here.",
+    "description": "Inventors toil with strange contraptions here, the air thick with the scent of oil and magic.",
     "exits": [
       "s"
     ],
@@ -31,14 +37,15 @@
       "s": "gearhaven_plaza"
     },
     "npcs": [
-      "thaldo_tinkerer"
+      "thaldo_tinkerer",
+      "gilda_crafter"
     ],
     "spawns": []
   },
   "shadowfen_camp": {
     "name": "Shadowfen Camp",
     "faction": "umbra",
-    "description": "A dark encampment surrounded by murky waters.",
+    "description": "A dark encampment surrounded by murky waters where warriors of Umbra sharpen their blades.",
     "exits": [
       "n",
       "e"
@@ -48,7 +55,11 @@
       "e": "shadowfen_bog"
     },
     "npcs": [
-      "bog_hunter"
+      "bog_hunter",
+      "shadra_shaman",
+      "gruk_trainer",
+      "morga_shadow",
+      "drezz_smith"
     ],
     "spawns": [
       "goblin_raider"
@@ -57,7 +68,7 @@
   "shadowfen_bog": {
     "name": "Shadowfen Bog",
     "faction": "umbra",
-    "description": "Thick mist blankets the soggy ground.",
+    "description": "Thick mist blankets the soggy ground and the croak of unseen creatures echoes all around.",
     "exits": [
       "w"
     ],
@@ -72,7 +83,7 @@
   "neutral_crossroads": {
     "name": "Crossroads",
     "faction": "neutral",
-    "description": "A meeting point of paths leading to many adventures.",
+    "description": "A dusty intersection where caravans pause and news from all factions is traded.",
     "exits": [
       "w"
     ],
@@ -80,7 +91,8 @@
       "w": "gearhaven_plaza"
     },
     "npcs": [
-      "ranger_npc"
+      "ranger_npc",
+      "traveling_merchant"
     ],
     "spawns": []
   }

--- a/data/npcs.json
+++ b/data/npcs.json
@@ -1,0 +1,129 @@
+{
+  "thaldo_tinkerer": {
+    "name": "Thaldo the Tinkerer",
+    "role": "Quest Giver",
+    "level": 5,
+    "description": "A gnome engineer with grease-smeared goggles always seeking new parts.",
+    "dialogue": [
+      "Welcome to Gearhaven! I've got gadgets aplenty if you've the curiosity."
+    ]
+  },
+  "gilda_crafter": {
+    "name": "Gilda Gearsmith",
+    "role": "Crafting Trainer",
+    "level": 3,
+    "description": "She hammers away at metal plates, teaching apprentices the trade.",
+    "dialogue": [
+      "Need to learn crafting? My workshop is open to all diligent hands."
+    ]
+  },
+  "rogar_trainer": {
+    "name": "Rogar Ironfist",
+    "role": "Warrior Trainer",
+    "level": 8,
+    "description": "A burly veteran who has fought in countless battles.",
+    "dialogue": [
+      "Strength and honor! Show me your stance if you seek training."
+    ]
+  },
+  "belena_trainer": {
+    "name": "Belena Lightbringer",
+    "role": "Cleric Trainer",
+    "level": 7,
+    "description": "Her armor gleams with the blessing of Solara.",
+    "dialogue": [
+      "The light guides those with faith. Join me in service to Solara."
+    ]
+  },
+  "bard_npc": {
+    "name": "Seren the Bard",
+    "role": "Quest Giver",
+    "level": 4,
+    "description": "A traveling musician who knows every tavern song.",
+    "dialogue": [
+      "Have you seen my lute? I swear I left it right here..."
+    ]
+  },
+  "druid_npc": {
+    "name": "Mira Greensong",
+    "role": "Quest Giver",
+    "level": 4,
+    "description": "A calm druid collecting herbs for her rituals.",
+    "dialogue": [
+      "The balance of nature must be preserved, even in a place of gears."
+    ]
+  },
+  "joran_barkeep": {
+    "name": "Joran Barkeep",
+    "role": "Innkeeper",
+    "level": 2,
+    "description": "He polishes mugs while sharing gossip of far lands.",
+    "dialogue": [
+      "Pull up a stool! Nothing chases away road dust like my stout."
+    ]
+  },
+  "bog_hunter": {
+    "name": "Cressa the Bog Hunter",
+    "role": "Quest Giver",
+    "level": 6,
+    "description": "She keeps watch for creatures slinking out of the mists.",
+    "dialogue": [
+      "Those bog creepers are getting bold. Think you could thin them out?"
+    ]
+  },
+  "shadra_shaman": {
+    "name": "Shadra the Shaman",
+    "role": "Shaman Trainer",
+    "level": 8,
+    "description": "Mystic runes glow faintly across her staff.",
+    "dialogue": [
+      "Spirits whisper of power for those who listen."
+    ]
+  },
+  "gruk_trainer": {
+    "name": "Gruk Crusher",
+    "role": "Warrior Trainer",
+    "level": 9,
+    "description": "An imposing orc teaching brutal combat techniques.",
+    "dialogue": [
+      "Show me your swing, little one. Gruk will make you strong!"
+    ]
+  },
+  "morga_shadow": {
+    "name": "Morga Shadowblade",
+    "role": "Rogue Trainer",
+    "level": 7,
+    "description": "Hard to spot even when she's standing in front of you.",
+    "dialogue": [
+      "Silence and speed, that's the art of survival."
+    ]
+  },
+  "drezz_smith": {
+    "name": "Drezz Smith",
+    "role": "Crafting Trainer",
+    "level": 5,
+    "description": "A gruff blacksmith pounding out crude but effective weapons.",
+    "dialogue": [
+      "If you bring the ore, I'll show you how to shape it."
+    ]
+  },
+  "ranger_npc": {
+    "name": "Elora the Ranger",
+    "role": "Quest Giver",
+    "level": 5,
+    "description": "She scouts the wilderness and keeps travelers safe.",
+    "dialogue": [
+      "The goblins are restless. I need fresh eyes on their camp." 
+    ]
+  },
+  "traveling_merchant": {
+    "name": "Lira the Merchant",
+    "role": "Trader",
+    "level": 3,
+    "description": "Her wagon overflows with wares from distant realms.",
+    "dialogue": [
+      "Coins jingle sweetest when they're leaving your purse and entering mine." 
+    ]
+  }
+}
+

--- a/index.html
+++ b/index.html
@@ -28,6 +28,11 @@
       <div id="status" class="hud-box">HP: --/-- MP: --/--</div>
       <div id="target" class="hud-box">Target: —</div>
       <div id="party" class="hud-box">Party: —</div>
+      <div id="npcs-box" class="hud-box">
+        <div class="font-bold mb-1">Nearby NPCs</div>
+        <div id="npc-list" class="flex flex-wrap gap-1"></div>
+      </div>
+      <div id="dialogue" class="hud-box hidden"></div>
     </aside>
   </main>
 

--- a/main.js
+++ b/main.js
@@ -7,6 +7,10 @@ const game = {
   combatTimer: 0
 };
 
+function isQuestGiver(id) {
+  return Object.values(loader.data.quests).some((q) => q.giver === id);
+}
+
 function rand(max) {
   return Math.floor(Math.random() * max) + 1;
 }
@@ -30,13 +34,17 @@ function addLog(txt) {
 
 function renderRoom(loc) {
   const log = document.getElementById('log');
+  const npcNames = loc.npcs
+    .map((id) => loader.get('npcs', id)?.name || id)
+    .join(', ') || 'None';
   log.innerHTML = `
     <h2 class="text-lg font-bold">${loc.name}</h2>
     <p>${loc.description}</p>
     <p><strong>Exits:</strong> ${loc.exits.join(', ')}</p>
-    <p><strong>NPCs:</strong> ${loc.npcs.join(', ') || 'None'}</p>
+    <p><strong>NPCs:</strong> ${npcNames}</p>
     <p><strong>Mobs:</strong> ${loc.spawns.join(', ') || 'None'}</p>
   `;
+  buildNPCList(loc.npcs);
 }
 
 function enterRoom(id) {
@@ -83,6 +91,60 @@ function startCombat(mobId) {
   clearInterval(game.combatTimer);
   game.combatTimer = setInterval(attackRound, 2000);
   updateHUD();
+  document.getElementById('dialogue').classList.add('hidden');
+}
+
+function attackNpc(id) {
+  const npc = loader.get('npcs', id);
+  if (npc && npc.hp) {
+    game.target = { ...npc };
+    clearInterval(game.combatTimer);
+    game.combatTimer = setInterval(attackRound, 2000);
+    updateHUD();
+  } else {
+    addLog(`${npc.name} does not seem interested in fighting.`);
+  }
+  document.getElementById('dialogue').classList.add('hidden');
+}
+
+function talkToNpc(id) {
+  const npc = loader.get('npcs', id);
+  if (!npc) return;
+  const line = npc.dialogue?.[0] || '...';
+  addLog(`${npc.name} says: "${line}"`);
+  document.getElementById('dialogue').classList.add('hidden');
+}
+
+function showNpcMenu(id) {
+  const npc = loader.get('npcs', id);
+  if (!npc) return;
+  const dlg = document.getElementById('dialogue');
+  dlg.innerHTML = `
+    <div class="font-bold mb-1">${npc.name}</div>
+    <div class="text-xs mb-2">${npc.role}</div>
+    <div class="flex gap-2">
+      <button id="talk" class="btn">Talk</button>
+      <button id="attack" class="btn">Attack</button>
+    </div>
+  `;
+  dlg.classList.remove('hidden');
+  document.getElementById('talk').onclick = () => talkToNpc(id);
+  document.getElementById('attack').onclick = () => attackNpc(id);
+}
+
+function buildNPCList(npcs) {
+  const list = document.getElementById('npc-list');
+  list.innerHTML = '';
+  npcs.forEach((id) => {
+    const npc = loader.get('npcs', id);
+    if (!npc) return;
+    const btn = document.createElement('button');
+    btn.className = 'npc-btn text-xs';
+    if (isQuestGiver(id)) btn.classList.add('quest');
+    btn.textContent = `${npc.name} (${npc.role})`;
+    btn.onclick = () => showNpcMenu(id);
+    list.append(btn);
+  });
 }
 
 function castSpell(id) {

--- a/style.css
+++ b/style.css
@@ -16,3 +16,11 @@ body {
 .btn {
   @apply px-3 py-1 bg-indigo-600 hover:bg-indigo-500 rounded;
 }
+
+/* NPC list buttons */
+.npc-btn {
+  @apply px-2 py-1 bg-slate-600 hover:bg-slate-500 rounded;
+}
+.quest {
+  @apply bg-amber-600 hover:bg-amber-500 text-black;
+}


### PR DESCRIPTION
## Summary
- load new `npcs.json` data
- flesh out city locations with many NPCs
- style NPC buttons and quest highlights
- render nearby NPC list and dialogue in HUD
- implement simple NPC interaction functions

## Testing
- `npm install`
- `npx eslint main.js data/*.json index.html style.css`

------
https://chatgpt.com/codex/tasks/task_e_6886a173d6d8832f90dc7f3fee1ac004