### PR TITLE
Improve UI panels and quest interaction

### DIFF
--- a/index.html
+++ b/index.html
@@ -28,6 +28,10 @@
       <div id="status" class="hud-box">HP: --/-- MP: --/--</div>
       <div id="target" class="hud-box">Target: —</div>
       <div id="party" class="hud-box">Party: —</div>
+      <div id="players-box" class="hud-box">
+        <div class="font-bold mb-1">Nearby Players</div>
+        <div id="player-list" class="flex flex-wrap gap-1"></div>
+      </div>
       <div id="npcs-box" class="hud-box">
         <div class="font-bold mb-1">Nearby NPCs</div>
         <div id="npc-list" class="flex flex-wrap gap-1"></div>
@@ -35,6 +39,18 @@
       <div id="dialogue" class="hud-box hidden"></div>
     </aside>
   </main>
+
+  <!-- Overlay panels -->
+  <div id="overlay" class="hidden fixed inset-0 bg-black/70 p-4 overflow-auto">
+    <div id="map" class="panel hidden bg-slate-800 p-4 rounded mb-4"></div>
+    <div id="inv" class="panel hidden bg-slate-800 p-4 rounded mb-4"></div>
+    <div id="craft" class="panel hidden bg-slate-800 p-4 rounded mb-4"></div>
+    <div id="quests" class="panel hidden bg-slate-800 p-4 rounded mb-4"></div>
+    <div id="chat-panel" class="panel hidden bg-slate-800 p-4 rounded mb-4"></div>
+    <div class="text-center">
+      <button id="close-overlay" class="btn">Close</button>
+    </div>
+  </div>
 
   <!-- Hotbar for abilities -->
   <div id="hotbar" class="shrink-0 p-2 bg-slate-800 flex gap-1 overflow-x-auto"></div>

--- a/main.js
+++ b/main.js
@@ -4,7 +4,8 @@ import { ws } from './websocket-stub.js';
 const game = {
   player: null,
   target: null,
-  combatTimer: 0
+  combatTimer: 0,
+  onlinePlayers: []
 };
 
 function isQuestGiver(id) {
@@ -32,17 +33,47 @@ function addLog(txt) {
   div.scrollIntoView();
 }
 
+function addChat(txt) {
+  const div = document.createElement('div');
+  div.textContent = txt;
+  document.getElementById('chat-panel').append(div);
+}
+
+function showPanel(name) {
+  const overlay = document.getElementById('overlay');
+  overlay.classList.remove('hidden');
+  document.querySelectorAll('#overlay .panel').forEach((p) => p.classList.add('hidden'));
+  document.getElementById(name).classList.remove('hidden');
+  if (name === 'inv') buildInventory();
+  if (name === 'quests') buildQuestList();
+  if (name === 'map') buildMap();
+}
+
 function renderRoom(loc) {
   const log = document.getElementById('log');
   const npcNames = loc.npcs
     .map((id) => loader.get('npcs', id)?.name || id)
+    .join(', ') || 'None';
+  const mobNames = loc.spawns
+    .map((id) => {
+      const mob = loader.data.mobs[id];
+      if (!mob) return id;
+      const diff = mob.level - game.player.level;
+      let color = 'text-white';
+      if (diff <= -3) color = 'text-green-400';
+      else if (diff <= -1) color = 'text-blue-400';
+      else if (diff <= 0) color = 'text-white';
+      else if (diff <= 2) color = 'text-yellow-400';
+      else color = 'text-red-600';
+      return `<span class="${color}">${mob.name}</span>`;
+    })
     .join(', ') || 'None';
   log.innerHTML = `
     <h2 class="text-lg font-bold">${loc.name}</h2>
     <p>${loc.description}</p>
     <p><strong>Exits:</strong> ${loc.exits.join(', ')}</p>
     <p><strong>NPCs:</strong> ${npcNames}</p>
-    <p><strong>Mobs:</strong> ${loc.spawns.join(', ') || 'None'}</p>
+    <p><strong>Mobs:</strong> ${mobNames}</p>
   `;
   buildNPCList(loc.npcs);
 }
@@ -54,6 +85,18 @@ function enterRoom(id) {
   location.hash = id;
   renderRoom(loc);
   updateHUD();
+}
+
+function updatePlayersList() {
+  const list = document.getElementById('player-list');
+  if (!list) return;
+  list.innerHTML = '';
+  game.onlinePlayers.forEach((p) => {
+    const btn = document.createElement('button');
+    btn.className = 'npc-btn text-xs';
+    btn.textContent = p;
+    list.append(btn);
+  });
 }
 
 function getWeaponDamage() {
@@ -122,14 +165,30 @@ function showNpcMenu(id) {
   dlg.innerHTML = `
     <div class="font-bold mb-1">${npc.name}</div>
     <div class="text-xs mb-2">${npc.role}</div>
-    <div class="flex gap-2">
+    <div class="flex gap-2 mb-2">
       <button id="talk" class="btn">Talk</button>
       <button id="attack" class="btn">Attack</button>
     </div>
+    <div id="quest-offers" class="flex flex-col gap-1"></div>
   `;
   dlg.classList.remove('hidden');
   document.getElementById('talk').onclick = () => talkToNpc(id);
   document.getElementById('attack').onclick = () => attackNpc(id);
+  const qdiv = document.getElementById('quest-offers');
+  Object.entries(loader.data.quests).forEach(([qid, q]) => {
+    if (q.giver !== id || game.player.activeQuests.includes(qid)) return;
+    const btn = document.createElement('button');
+    btn.className = 'text-red-400 underline text-left';
+    btn.textContent = `[${q.name}]`;
+    btn.onclick = () => {
+      if (window.confirm(`Accept quest "${q.name}"?`)) {
+        game.player.activeQuests.push(qid);
+        addLog(`Quest accepted: ${q.name}`);
+        dlg.classList.add('hidden');
+      }
+    };
+    qdiv.append(btn);
+  });
 }
 
 function buildNPCList(npcs) {
@@ -166,6 +225,71 @@ function buildHotbar() {
   });
 }
 
+function buildInventory() {
+  const inv = document.getElementById('inv');
+  inv.innerHTML = '<h2 class="text-lg mb-2">Inventory</h2>';
+  const list = document.createElement('ul');
+  game.player.inventory.forEach((id) => {
+    const li = document.createElement('li');
+    li.textContent = loader.data.items[id]?.name || id;
+    list.append(li);
+  });
+  inv.append(list);
+}
+
+function buildQuestList() {
+  const qpanel = document.getElementById('quests');
+  qpanel.innerHTML = '<h2 class="text-lg mb-2">Active Quests</h2>';
+  const list = document.createElement('ul');
+  game.player.activeQuests.forEach((qid) => {
+    const q = loader.data.quests[qid];
+    if (!q) return;
+    const li = document.createElement('li');
+    li.textContent = q.name;
+    list.append(li);
+  });
+  qpanel.append(list);
+}
+
+function findPath(start, end) {
+  const queue = [[start]];
+  const visited = new Set([start]);
+  while (queue.length) {
+    const path = queue.shift();
+    const node = path[path.length - 1];
+    if (node === end) return path;
+    const links = loader.data.locations[node].links || {};
+    Object.values(links).forEach((n) => {
+      if (!visited.has(n)) {
+        visited.add(n);
+        queue.push([...path, n]);
+      }
+    });
+  }
+  return null;
+}
+
+function buildMap() {
+  const map = document.getElementById('map');
+  map.innerHTML = '<h2 class="text-lg mb-2">World Map</h2>';
+  const list = document.createElement('ul');
+  Object.entries(loader.data.locations).forEach(([id, loc]) => {
+    const li = document.createElement('li');
+    const btn = document.createElement('button');
+    btn.className = 'underline text-sky-400';
+    btn.textContent = loc.name;
+    btn.onclick = () => {
+      const path = findPath(game.player.location, id);
+      if (path) {
+        addLog(`Route to ${loc.name}: ${path.join(' -> ')}`);
+      }
+    };
+    li.append(btn);
+    list.append(li);
+  });
+  map.append(list);
+}
+
 function handleInput(text) {
   const cmd = text.trim();
   if (['n', 's', 'e', 'w'].includes(cmd)) {
@@ -174,6 +298,8 @@ function handleInput(text) {
   } else if (cmd.startsWith('/attack')) {
     const mob = loader.data.locations[game.player.location].spawns[0];
     if (mob) startCombat(mob);
+  } else if (cmd === '/who') {
+    addLog(`Online: ${game.onlinePlayers.join(', ')}`);
   } else if (cmd) {
     ws.send('chat', { channel: 'say', msg: `${game.player.name}: ${cmd}` });
   }
@@ -188,7 +314,16 @@ function bindUI() {
   document.getElementById('cmd').addEventListener('keydown', (e) => {
     if (e.key === 'Enter') document.getElementById('send').click();
   });
-  ws.on('chat', (m) => addLog(`[${m.channel}] ${m.msg}`));
+  ws.on('chat', (m) => {
+    addLog(`[${m.channel}] ${m.msg}`);
+    addChat(`[${m.channel}] ${m.msg}`);
+  });
+  document.querySelectorAll('button[data-panel]').forEach((btn) => {
+    btn.onclick = () => showPanel(btn.dataset.panel);
+  });
+  document.getElementById('close-overlay').onclick = () => {
+    document.getElementById('overlay').classList.add('hidden');
+  };
 }
 
 export async function init() {
@@ -197,6 +332,7 @@ export async function init() {
     name: 'Hero',
     class: 'warrior',
     race: 'human',
+    level: 1,
     stats: { str: 10, dex: 8, int: 5, wis: 5, spi: 5, vit: 10 },
     hp: 50,
     maxHp: 50,
@@ -208,6 +344,8 @@ export async function init() {
     activeQuests: ['welcome_to_realm'],
     party: []
   };
+  game.onlinePlayers = ['Hero', 'Adventurer', 'Mystic'];
+  updatePlayersList();
   bindUI();
   buildHotbar();
   const start = location.hash.slice(1) || game.player.location;

--- a/style.css
+++ b/style.css
@@ -24,3 +24,8 @@ body {
 .quest {
   @apply bg-amber-600 hover:bg-amber-500 text-black;
 }
+
+/* Overlay panels */
+.panel {
+  @apply w-full md:w-2/3 mx-auto;
+}


### PR DESCRIPTION
## Summary
- add overlay panels for map, inventory, crafting, quests and chat
- show nearby players in HUD and render online players
- color mobs by difficulty and show quest offers with acceptance prompt
- build inventory, quest list and map dynamically
- wire up header buttons to open panels and handle chat separately

## Testing
- `npm install`
- `npx eslint .`


------
https://chatgpt.com/codex/tasks/task_e_6886a49e4b40832f9a50f10a064d2315