### PR TITLE
Implement targeting and help command

### DIFF
--- a/data/loader.js
+++ b/data/loader.js
@@ -11,7 +11,8 @@ export const loader = {
       'quests',
       'locations',
       'mobs',
-      'npcs'
+      'npcs',
+      'nodes'
     ];
     await Promise.all(
       files.map(async (name) => {

--- a/data/locations.json
+++ b/data/locations.json
@@ -24,6 +24,9 @@
     ],
     "spawns": [
       "rogue_clockwork"
+    ],
+    "nodes": [
+      "gearhaven_sign"
     ]
   },
   "gearhaven_workshop": {
@@ -40,7 +43,10 @@
       "thaldo_tinkerer",
       "gilda_crafter"
     ],
-    "spawns": []
+    "spawns": [],
+    "nodes": [
+      "workshop_anvil"
+    ]
   },
   "shadowfen_camp": {
     "name": "Shadowfen Camp",
@@ -78,6 +84,9 @@
     "npcs": [],
     "spawns": [
       "bog_creeper"
+    ],
+    "nodes": [
+      "bog_stone"
     ]
   },
   "neutral_crossroads": {
@@ -94,6 +103,7 @@
       "ranger_npc",
       "traveling_merchant"
     ],
-    "spawns": []
+    "spawns": [],
+    "nodes": []
   }
 }

--- a/data/nodes.json
+++ b/data/nodes.json
@@ -1,0 +1,20 @@
+{
+  "gearhaven_sign": {
+    "name": "Town Sign",
+    "description": "A weathered sign welcoming visitors to Gearhaven.",
+    "dialogue": ["Welcome to Gearhaven!"],
+    "color": "text-cyan-400"
+  },
+  "workshop_anvil": {
+    "name": "Sturdy Anvil",
+    "description": "Blacksmiths shape metal here.",
+    "dialogue": ["You hear the ring of hammer strikes."],
+    "color": "text-orange-400"
+  },
+  "bog_stone": {
+    "name": "Mysterious Stone",
+    "description": "Strange runes glow faintly on its surface.",
+    "dialogue": ["The stone hums with unknown power."],
+    "color": "text-purple-400"
+  }
+}

--- a/index.html
+++ b/index.html
@@ -32,6 +32,10 @@
         <div class="font-bold mb-1">Nearby NPCs</div>
         <div id="npc-list" class="flex flex-wrap gap-1"></div>
       </div>
+      <div id="nodes-box" class="hud-box">
+        <div class="font-bold mb-1">Objects & Nodes</div>
+        <div id="node-list" class="flex flex-wrap gap-1"></div>
+      </div>
       <div id="dialogue" class="hud-box hidden"></div>
     </aside>
   </main>

--- a/main.js
+++ b/main.js
@@ -7,12 +7,29 @@ const game = {
   combatTimer: 0
 };
 
+let currentTargetBtn = null;
+
 function isQuestGiver(id) {
   return Object.values(loader.data.quests).some((q) => q.giver === id);
 }
 
 function rand(max) {
   return Math.floor(Math.random() * max) + 1;
+}
+
+function selectTarget(type, id, btn) {
+  if (currentTargetBtn) currentTargetBtn.classList.remove('targeted');
+  currentTargetBtn = btn || null;
+  if (currentTargetBtn) currentTargetBtn.classList.add('targeted');
+  if (type === 'npc') {
+    game.target = { ...loader.get('npcs', id), id, type };
+  } else if (type === 'node') {
+    game.target = { ...loader.get('nodes', id), id, type };
+  } else {
+    game.target = null;
+  }
+  document.getElementById('dialogue').classList.add('hidden');
+  updateHUD();
 }
 
 function updateHUD() {
@@ -37,14 +54,19 @@ function renderRoom(loc) {
   const npcNames = loc.npcs
     .map((id) => loader.get('npcs', id)?.name || id)
     .join(', ') || 'None';
+  const nodeNames = (loc.nodes || [])
+    .map((id) => loader.get('nodes', id)?.name || id)
+    .join(', ') || 'None';
   log.innerHTML = `
     <h2 class="text-lg font-bold">${loc.name}</h2>
     <p>${loc.description}</p>
     <p><strong>Exits:</strong> ${loc.exits.join(', ')}</p>
     <p><strong>NPCs:</strong> ${npcNames}</p>
     <p><strong>Mobs:</strong> ${loc.spawns.join(', ') || 'None'}</p>
+    <p><strong>Objects:</strong> ${nodeNames}</p>
   `;
   buildNPCList(loc.npcs);
+  buildNodeList(loc.nodes || []);
 }
 
 function enterRoom(id) {
@@ -142,7 +164,22 @@ function buildNPCList(npcs) {
     btn.className = 'npc-btn text-xs';
     if (isQuestGiver(id)) btn.classList.add('quest');
     btn.textContent = `${npc.name} (${npc.role})`;
-    btn.onclick = () => showNpcMenu(id);
+    btn.onclick = () => selectTarget('npc', id, btn);
+    btn.ondblclick = () => showNpcMenu(id);
+    list.append(btn);
+  });
+}
+
+function buildNodeList(nodes) {
+  const list = document.getElementById('node-list');
+  list.innerHTML = '';
+  (nodes || []).forEach((id) => {
+    const node = loader.get('nodes', id);
+    if (!node) return;
+    const btn = document.createElement('button');
+    btn.className = `node-btn text-xs ${node.color || ''}`;
+    btn.textContent = node.name;
+    btn.onclick = () => selectTarget('node', id, btn);
     list.append(btn);
   });
 }
@@ -166,6 +203,29 @@ function buildHotbar() {
   });
 }
 
+function showHelp() {
+  addLog('Commands:');
+  addLog(' n,s,e,w - move');
+  addLog(' /attack - attack a nearby mob');
+  addLog(' hail - speak to your target');
+  addLog(' /target <name> - target an NPC or object by name');
+  addLog(' /help - show this help');
+}
+
+function targetByName(name) {
+  const loc = loader.data.locations[game.player.location];
+  const ids = [...loc.npcs, ...(loc.nodes || [])];
+  for (const id of ids) {
+    const ent = loader.get('npcs', id) || loader.get('nodes', id);
+    if (ent && ent.name.toLowerCase().includes(name.toLowerCase())) {
+      const type = loader.get('npcs', id) ? 'npc' : 'node';
+      selectTarget(type, id);
+      return true;
+    }
+  }
+  return false;
+}
+
 function handleInput(text) {
   const cmd = text.trim();
   if (['n', 's', 'e', 'w'].includes(cmd)) {
@@ -174,6 +234,21 @@ function handleInput(text) {
   } else if (cmd.startsWith('/attack')) {
     const mob = loader.data.locations[game.player.location].spawns[0];
     if (mob) startCombat(mob);
+  } else if (cmd.startsWith('/target')) {
+    const name = cmd.slice(7).trim();
+    if (!targetByName(name)) addLog('No such target here.');
+  } else if (cmd === 'hail') {
+    if (!game.target) {
+      addLog('You have no target.');
+    } else if (game.target.type === 'npc') {
+      talkToNpc(game.target.id);
+    } else if (game.target.dialogue) {
+      addLog(game.target.dialogue[0]);
+    } else {
+      addLog('Nothing happens.');
+    }
+  } else if (cmd === '/help') {
+    showHelp();
   } else if (cmd) {
     ws.send('chat', { channel: 'say', msg: `${game.player.name}: ${cmd}` });
   }

--- a/style.css
+++ b/style.css
@@ -24,3 +24,13 @@ body {
 .quest {
   @apply bg-amber-600 hover:bg-amber-500 text-black;
 }
+
+/* Node list buttons */
+.node-btn {
+  @apply px-2 py-1 bg-slate-600 hover:bg-slate-500 rounded;
+}
+
+/* Target highlight */
+.targeted {
+  @apply border border-yellow-300;
+}


### PR DESCRIPTION
## Summary
- add data for interactive nodes
- load nodes in the data loader and locations
- show objects/nodes in HUD sidebar
- implement selection highlighting for NPCs and nodes
- add `/help`, `hail` and `/target` commands

## Testing
- `npm install`
- `npx eslint main.js data/loader.js`
- `node -c main.js`

------
https://chatgpt.com/codex/tasks/task_e_6886a52a6564832fab51828a0519c337