### PR TITLE
Add clickable navigation and expand world

### DIFF
--- a/data/locations.json
+++ b/data/locations.json
@@ -85,15 +85,180 @@
     "faction": "neutral",
     "description": "A dusty intersection where caravans pause and news from all factions is traded.",
     "exits": [
-      "w"
+      "gearhaven_plaza",
+      "elven_glade_path",
+      "dwarf_fort_path",
+      "gnome_burrow_path",
+      "orc_stronghold_path",
+      "undead_trail"
     ],
     "links": {
-      "w": "gearhaven_plaza"
+      "west": "gearhaven_plaza",
+      "elven_path": "elven_glade_path",
+      "dwarf_path": "dwarf_fort_path",
+      "gnome_path": "gnome_burrow_path",
+      "orc_path": "orc_stronghold_path",
+      "undead_path": "undead_trail"
     },
     "npcs": [
       "ranger_npc",
       "traveling_merchant"
     ],
+    "spawns": []
+  },
+  "elven_glade_path": {
+    "name": "Elven Forest Road",
+    "faction": "neutral",
+    "description": "A serene path lined with ancient trees leading to the high elf city.",
+    "exits": [
+      "neutral_crossroads",
+      "elven_glade"
+    ],
+    "links": {
+      "crossroads": "neutral_crossroads",
+      "city": "elven_glade"
+    },
+    "npcs": [],
+    "spawns": []
+  },
+  "elven_glade": {
+    "name": "Elven Glade",
+    "faction": "luminara",
+    "description": "Homes built high in the trees sparkle with arcane light.",
+    "exits": [
+      "elven_glade_path"
+    ],
+    "links": {
+      "road": "elven_glade_path"
+    },
+    "npcs": [],
+    "spawns": []
+  },
+  "dwarf_fort_path": {
+    "name": "Stone Tunnel",
+    "faction": "neutral",
+    "description": "A well-carved tunnel slopes downward toward a dwarven stronghold.",
+    "exits": [
+      "neutral_crossroads",
+      "dwarf_fortress"
+    ],
+    "links": {
+      "crossroads": "neutral_crossroads",
+      "city": "dwarf_fortress"
+    },
+    "npcs": [],
+    "spawns": []
+  },
+  "dwarf_fortress": {
+    "name": "Dwarf Fortress",
+    "faction": "luminara",
+    "description": "Massive stone walls guard the halls of the stout folk.",
+    "exits": [
+      "dwarf_fort_path"
+    ],
+    "links": {
+      "road": "dwarf_fort_path"
+    },
+    "npcs": [],
+    "spawns": []
+  },
+  "gnome_burrow_path": {
+    "name": "Gnome Tunnel",
+    "faction": "neutral",
+    "description": "A cramped tunnel lit by flickering lanterns.",
+    "exits": [
+      "neutral_crossroads",
+      "gnome_burrow"
+    ],
+    "links": {
+      "crossroads": "neutral_crossroads",
+      "city": "gnome_burrow"
+    },
+    "npcs": [],
+    "spawns": []
+  },
+  "gnome_burrow": {
+    "name": "Gnome Burrow",
+    "faction": "luminara",
+    "description": "A maze of cozy burrows bustling with tinkering gnomes.",
+    "exits": [
+      "gnome_burrow_path"
+    ],
+    "links": {
+      "road": "gnome_burrow_path"
+    },
+    "npcs": [],
+    "spawns": []
+  },
+  "orc_stronghold_path": {
+    "name": "Blasted Trail",
+    "faction": "neutral",
+    "description": "A rough trail littered with bones leading to the orc stronghold.",
+    "exits": [
+      "neutral_crossroads",
+      "orc_stronghold"
+    ],
+    "links": {
+      "crossroads": "neutral_crossroads",
+      "city": "orc_stronghold"
+    },
+    "npcs": [],
+    "spawns": []
+  },
+  "orc_stronghold": {
+    "name": "Orc Stronghold",
+    "faction": "umbra",
+    "description": "A fortified camp echoing with war drums.",
+    "exits": [
+      "orc_stronghold_path"
+    ],
+    "links": {
+      "road": "orc_stronghold_path"
+    },
+    "npcs": [],
+    "spawns": []
+  },
+  "undead_trail": {
+    "name": "Forsaken Path",
+    "faction": "neutral",
+    "description": "A chilling road lined with the remnants of battles long past.",
+    "exits": [
+      "neutral_crossroads",
+      "undead_necropolis"
+    ],
+    "links": {
+      "crossroads": "neutral_crossroads",
+      "city": "undead_necropolis"
+    },
+    "npcs": [],
+    "spawns": []
+  },
+  "undead_necropolis": {
+    "name": "Undead Necropolis",
+    "faction": "umbra",
+    "description": "Crumbling mausoleums rise from dark soil under a perpetual gloom.",
+    "exits": [
+      "undead_trail"
+    ],
+    "links": {
+      "road": "undead_trail"
+    },
+    "boats": [
+      "dawn_isle_port"
+    ],
+    "npcs": [],
+    "spawns": []
+  },
+  "dawn_isle_port": {
+    "name": "Dawn Isle Port",
+    "faction": "luminara",
+    "description": "A small harbor where boats depart for distant lands.",
+    "exits": [],
+    "links": {},
+    "boats": [
+      "undead_necropolis"
+    ],
+    "npcs": [],
     "spawns": []
   }
 }

--- a/data/races.json
+++ b/data/races.json
@@ -7,41 +7,41 @@
   "high_elf": {
     "name": "High Elf",
     "faction": "luminara",
-    "startLocation": "gearhaven_plaza"
+    "startLocation": "elven_glade"
   },
   "dwarf": {
     "name": "Dwarf",
     "faction": "luminara",
-    "startLocation": "gearhaven_plaza"
+    "startLocation": "dwarf_fortress"
   },
   "gnome": {
     "name": "Gnome",
     "faction": "luminara",
-    "startLocation": "gearhaven_plaza"
+    "startLocation": "gnome_burrow"
   },
   "orc": {
     "name": "Orc",
     "faction": "umbra",
-    "startLocation": "shadowfen_camp"
+    "startLocation": "orc_stronghold"
   },
   "dark_elf": {
     "name": "Dark Elf",
     "faction": "umbra",
-    "startLocation": "shadowfen_camp"
+    "startLocation": "orc_stronghold"
   },
   "troll": {
     "name": "Troll",
     "faction": "umbra",
-    "startLocation": "shadowfen_camp"
+    "startLocation": "orc_stronghold"
   },
   "undead": {
     "name": "Undead",
     "faction": "umbra",
-    "startLocation": "shadowfen_camp"
+    "startLocation": "undead_necropolis"
   },
   "goblin": {
     "name": "Goblin",
     "faction": "umbra",
-    "startLocation": "shadowfen_camp"
+    "startLocation": "orc_stronghold"
   }
 }

--- a/index.html
+++ b/index.html
@@ -37,6 +37,10 @@
         <div class="font-bold mb-1">Nearby NPCs</div>
         <div id="npc-list" class="flex flex-wrap gap-1"></div>
       </div>
+      <div id="mobs-box" class="hud-box">
+        <div class="font-bold mb-1">Nearby Mobs</div>
+        <div id="mob-list" class="flex flex-wrap gap-1"></div>
+      </div>
       <div id="dialogue" class="hud-box hidden"></div>
     </aside>
   </main>

--- a/main.js
+++ b/main.js
@@ -123,14 +123,33 @@ function renderRoom(loc) {
       return `<span class="${color}">${mob.name}</span>`;
     })
     .join(', ') || 'None';
+
+  const exitButtons = Object.entries(loc.links || {})
+    .map(([key, dest]) => {
+      const d = loader.data.locations[dest];
+      const name = d ? d.name : dest;
+      return `<button class="exit-btn underline text-sky-400" data-dest="${dest}">${name}</button>`;
+    })
+    .concat(
+      (loc.boats || []).map(
+        (dest) =>
+          `<button class="exit-btn underline text-teal-400" data-dest="${dest}">Sail to ${loader.data.locations[dest]?.name || dest}</button>`
+      )
+    )
+    .join(', ') || 'None';
+
   log.innerHTML = `
     <h2 class="text-lg font-bold">${loc.name}</h2>
     <p>${loc.description}</p>
-    <p><strong>Exits:</strong> ${loc.exits.join(', ')}</p>
+    <p><strong>Travel:</strong> ${exitButtons}</p>
     <p><strong>NPCs:</strong> ${npcNames}</p>
     <p><strong>Mobs:</strong> ${mobNames}</p>
   `;
+  log.querySelectorAll('.exit-btn').forEach((btn) => {
+    btn.onclick = () => enterRoom(btn.dataset.dest);
+  });
   buildNPCList(loc.npcs);
+  buildMobList(loc.spawns);
 }
 
 function enterRoom(id) {
@@ -274,6 +293,26 @@ function buildNPCList(npcs) {
   });
 }
 
+function buildMobList(mobs) {
+  const list = document.getElementById('mob-list');
+  if (!list) return;
+  list.innerHTML = '';
+  mobs.forEach((id) => {
+    const mob = loader.data.mobs[id];
+    if (!mob) return;
+    const span = document.createElement('span');
+    span.className = 'text-xs mr-1';
+    const diff = mob.level - game.player.level;
+    let color = 'text-white';
+    if (diff > 2) color = 'text-red-600';
+    else if (diff > 0) color = 'text-yellow-400';
+    else if (diff < -1) color = 'text-green-400';
+    span.classList.add(color);
+    span.textContent = mob.name;
+    list.append(span);
+  });
+}
+
 function castSpell(id) {
   const spell = loader.data.spells[id];
   if (!spell) return;
@@ -327,8 +366,15 @@ function findPath(start, end) {
     const path = queue.shift();
     const node = path[path.length - 1];
     if (node === end) return path;
-    const links = loader.data.locations[node].links || {};
+    const loc = loader.data.locations[node];
+    const links = loc.links || {};
     Object.values(links).forEach((n) => {
+      if (!visited.has(n)) {
+        visited.add(n);
+        queue.push([...path, n]);
+      }
+    });
+    (loc.boats || []).forEach((n) => {
       if (!visited.has(n)) {
         visited.add(n);
         queue.push([...path, n]);
@@ -364,6 +410,12 @@ function handleInput(text) {
   if (['n', 's', 'e', 'w'].includes(cmd)) {
     const dest = loader.data.locations[game.player.location].links[cmd];
     if (dest) enterRoom(dest);
+  } else if (cmd.startsWith('/goto ')) {
+    const target = cmd.slice(6);
+    const loc = loader.data.locations[game.player.location];
+    const linkDest = Object.values(loc.links || {}).find((v) => v === target);
+    const boatDest = (loc.boats || []).find((v) => v === target);
+    if (linkDest || boatDest) enterRoom(target);
   } else if (cmd.startsWith('/attack')) {
     const mob = loader.data.locations[game.player.location].spawns[0];
     if (mob) startCombat(mob);

--- a/style.css
+++ b/style.css
@@ -24,6 +24,9 @@ body {
 .quest {
   @apply bg-amber-600 hover:bg-amber-500 text-black;
 }
+.exit-btn {
+  @apply underline text-sky-400 hover:text-sky-300;
+}
 
 /* Overlay panels */
 .panel {


### PR DESCRIPTION
## Summary
- show nearby mobs in HUD
- add clickable travel buttons for each location and sailing routes
- support `/goto` command for direct travel
- expand world with new cities and connecting zones
- update race starting locations
- style exit buttons

## Testing
- `node -v`
- `yes | npx eslint .` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6886a875a490832f8cce381469883305