### PR TITLE
Add crafting professions

### DIFF
--- a/data/crafting.json
+++ b/data/crafting.json
@@ -1,0 +1,52 @@
+{
+  "blacksmithing": {
+    "name": "Blacksmithing",
+    "recipes": {
+      "iron_sword": {
+        "result": "rusty_sword",
+        "materials": { "iron_ore": 3, "wood_plank": 1 }
+      }
+    }
+  },
+  "tailoring": {
+    "name": "Tailoring",
+    "recipes": {
+      "leather_armor": {
+        "result": "leather_armor",
+        "materials": { "cloth_scrap": 4 }
+      }
+    }
+  },
+  "alchemy": {
+    "name": "Alchemy",
+    "recipes": {
+      "healing_potion": {
+        "result": "healing_potion",
+        "materials": { "herb_leaf": 2, "water": 1 }
+      }
+    }
+  },
+  "enchanting": {
+    "name": "Enchanting",
+    "recipes": {
+      "mana_potion": {
+        "result": "mana_potion",
+        "materials": { "arcane_dust": 2, "water": 1 }
+      }
+    }
+  },
+  "fletching": {
+    "name": "Fletching",
+    "recipes": {
+      "hunter_bow": {
+        "result": "hunter_bow",
+        "materials": { "wood_plank": 2, "feather": 2 }
+      }
+    }
+  },
+  "brewing": { "name": "Brewing", "recipes": {} },
+  "baking": { "name": "Baking", "recipes": {} },
+  "jewelry": { "name": "Jewelry", "recipes": {} },
+  "pottery": { "name": "Pottery", "recipes": {} },
+  "research": { "name": "Research", "recipes": {} }
+}

--- a/data/items.json
+++ b/data/items.json
@@ -65,5 +65,40 @@
     "level": 1,
     "slot": "offhand",
     "description": "Lights the way in dark places."
+  },
+  "iron_ore": {
+    "name": "Iron Ore",
+    "level": 1,
+    "description": "Ore used in basic smithing."
+  },
+  "wood_plank": {
+    "name": "Wood Plank",
+    "level": 1,
+    "description": "A sturdy piece of wood for crafting."
+  },
+  "cloth_scrap": {
+    "name": "Cloth Scrap",
+    "level": 1,
+    "description": "Bits of cloth useful for tailoring."
+  },
+  "herb_leaf": {
+    "name": "Herb Leaf",
+    "level": 1,
+    "description": "A common herb used in alchemy."
+  },
+  "arcane_dust": {
+    "name": "Arcane Dust",
+    "level": 1,
+    "description": "Residue left from disenchanted items."
+  },
+  "feather": {
+    "name": "Feather",
+    "level": 1,
+    "description": "Useful for fletching arrows."
+  },
+  "water": {
+    "name": "Water Flask",
+    "level": 1,
+    "description": "Used in many recipes."
   }
 }

--- a/data/loader.js
+++ b/data/loader.js
@@ -11,7 +11,8 @@ export const loader = {
       'quests',
       'locations',
       'mobs',
-      'npcs'
+      'npcs',
+      'crafting'
     ];
     await Promise.all(
       files.map(async (name) => {

--- a/data/npcs.json
+++ b/data/npcs.json
@@ -15,7 +15,8 @@
     "description": "She hammers away at metal plates, teaching apprentices the trade.",
     "dialogue": [
       "Need to learn crafting? My workshop is open to all diligent hands."
-    ]
+    ],
+    "teaches": ["blacksmithing", "tailoring"]
   },
   "rogar_trainer": {
     "name": "Rogar Ironfist",
@@ -51,7 +52,8 @@
     "description": "A calm druid collecting herbs for her rituals.",
     "dialogue": [
       "The balance of nature must be preserved, even in a place of gears."
-    ]
+    ],
+    "teaches": ["alchemy"]
   },
   "joran_barkeep": {
     "name": "Joran Barkeep",
@@ -60,7 +62,8 @@
     "description": "He polishes mugs while sharing gossip of far lands.",
     "dialogue": [
       "Pull up a stool! Nothing chases away road dust like my stout."
-    ]
+    ],
+    "teaches": ["brewing", "baking"]
   },
   "bog_hunter": {
     "name": "Cressa the Bog Hunter",
@@ -78,7 +81,8 @@
     "description": "Mystic runes glow faintly across her staff.",
     "dialogue": [
       "Spirits whisper of power for those who listen."
-    ]
+    ],
+    "teaches": ["enchanting"]
   },
   "gruk_trainer": {
     "name": "Gruk Crusher",
@@ -105,7 +109,8 @@
     "description": "A gruff blacksmith pounding out crude but effective weapons.",
     "dialogue": [
       "If you bring the ore, I'll show you how to shape it."
-    ]
+    ],
+    "teaches": ["blacksmithing"]
   },
   "ranger_npc": {
     "name": "Elora the Ranger",
@@ -113,8 +118,9 @@
     "level": 5,
     "description": "She scouts the wilderness and keeps travelers safe.",
     "dialogue": [
-      "The goblins are restless. I need fresh eyes on their camp." 
-    ]
+      "The goblins are restless. I need fresh eyes on their camp."
+    ],
+    "teaches": ["fletching"]
   },
   "traveling_merchant": {
     "name": "Lira the Merchant",
@@ -122,8 +128,9 @@
     "level": 3,
     "description": "Her wagon overflows with wares from distant realms.",
     "dialogue": [
-      "Coins jingle sweetest when they're leaving your purse and entering mine." 
-    ]
+      "Coins jingle sweetest when they're leaving your purse and entering mine."
+    ],
+    "teaches": ["pottery", "jewelry"]
   }
 }
 

--- a/main.js
+++ b/main.js
@@ -160,6 +160,7 @@ function showPanel(name) {
   if (name === 'inv') buildInventory();
   if (name === 'quests') buildQuestList();
   if (name === 'map') buildMap();
+  if (name === 'craft') buildCraftPanel();
 }
 
 function renderRoom(loc) {
@@ -296,6 +297,7 @@ function showNpcMenu(id) {
       <button id="attack" class="btn">Attack</button>
     </div>
     <div id="quest-offers" class="flex flex-col gap-1"></div>
+    <div id="training" class="flex flex-col gap-1 mt-2"></div>
   `;
   dlg.classList.remove('hidden');
   document.getElementById('talk').onclick = () => talkToNpc(id);
@@ -314,6 +316,19 @@ function showNpcMenu(id) {
       }
     };
     qdiv.append(btn);
+  });
+  const tdiv = document.getElementById('training');
+  (npc.teaches || []).forEach((prof) => {
+    if (game.player.professions.includes(prof)) return;
+    const btn = document.createElement('button');
+    btn.className = 'btn text-xs';
+    btn.textContent = `Learn ${loader.data.crafting[prof].name}`;
+    btn.onclick = () => {
+      game.player.professions.push(prof);
+      addLog(`You learn ${loader.data.crafting[prof].name}.`);
+      dlg.classList.add('hidden');
+    };
+    tdiv.append(btn);
   });
 }
 
@@ -417,6 +432,70 @@ function buildMap() {
   map.append(list);
 }
 
+function craftItem(prof, rid) {
+  if (!game.player.professions.includes(prof)) {
+    addLog('You have not learned that profession.');
+    return;
+  }
+  const recipe = loader.data.crafting[prof].recipes[rid];
+  const mats = recipe.materials;
+  for (const [mat, qty] of Object.entries(mats)) {
+    const count = game.player.inventory.filter((i) => i === mat).length;
+    if (count < qty) {
+      addLog('Missing materials.');
+      return;
+    }
+  }
+  for (const [mat, qty] of Object.entries(mats)) {
+    let remaining = qty;
+    for (let i = game.player.inventory.length - 1; i >= 0 && remaining > 0; i--) {
+      if (game.player.inventory[i] === mat) {
+        game.player.inventory.splice(i, 1);
+        remaining--;
+      }
+    }
+  }
+  game.player.inventory.push(recipe.result);
+  addLog(`You craft ${loader.data.items[recipe.result].name}.`);
+  buildInventory();
+}
+
+function showRecipes(prof) {
+  const div = document.getElementById('recipe-list');
+  div.innerHTML = `<h3 class="font-bold mb-1">${loader.data.crafting[prof].name}</h3>`;
+  Object.entries(loader.data.crafting[prof].recipes).forEach(([rid, r]) => {
+    const btn = document.createElement('button');
+    const req = Object.entries(r.materials)
+      .map(([m, q]) => `${q} ${loader.data.items[m].name}`)
+      .join(', ');
+    btn.className = 'btn text-xs mt-1';
+    btn.textContent = `Craft ${loader.data.items[r.result].name} (${req})`;
+    if (!game.player.professions.includes(prof)) btn.disabled = true;
+    btn.onclick = () => craftItem(prof, rid);
+    div.append(btn);
+  });
+}
+
+function buildCraftPanel() {
+  const panel = document.getElementById('craft');
+  panel.innerHTML = '<h2 class="text-lg mb-2">Crafting</h2>';
+  const list = document.createElement('ul');
+  Object.entries(loader.data.crafting).forEach(([pid, prof]) => {
+    const li = document.createElement('li');
+    const btn = document.createElement('button');
+    btn.className = 'underline text-sky-400';
+    const trained = game.player.professions.includes(pid) ? '' : ' (untrained)';
+    btn.textContent = prof.name + trained;
+    btn.onclick = () => showRecipes(pid);
+    li.append(btn);
+    list.append(li);
+  });
+  panel.append(list);
+  const div = document.createElement('div');
+  div.id = 'recipe-list';
+  panel.append(div);
+}
+
 function handleInput(text) {
   const cmd = text.trim();
   if (['n', 's', 'e', 'w'].includes(cmd)) {
@@ -487,6 +566,7 @@ export async function init() {
     coins: { gold: 0, silver: 0, copper: 0 },
     equipped: { weapon: 'rusty_sword' },
     activeQuests: ['welcome_to_realm'],
+    professions: [],
     party: []
   };
   game.onlinePlayers = ['Hero', 'Adventurer', 'Mystic'];

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,25 @@
+{
+  "name": "realm",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "devDependencies": {
+        "@eslint/js": "^9.32.0"
+      }
+    },
+    "node_modules/@eslint/js": {
+      "version": "9.32.0",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.32.0.tgz",
+      "integrity": "sha512-BBpRFZK3eX6uMLKz8WxFOBIFFcGFJ/g8XuwjTHCqHROSIsopI+ddn/d5Cfh36+7+e5edVS8dbSHnBNhrLEX0zg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- define crafting materials and add multiple crafting professions
- load crafting data in the loader
- allow trainers to teach crafting professions
- create crafting panel with recipes and training buttons
- include node dependencies

## Testing
- `npm install`
- `npx eslint main.js`

------
https://chatgpt.com/codex/tasks/task_e_6886a95578b0832fa3440b69667bd618