### PR TITLE
Add context-sensitive actions

### DIFF
--- a/index.html
+++ b/index.html
@@ -45,6 +45,10 @@
         <div class="font-bold mb-1">Nearby Objects</div>
         <div id="node-list" class="flex flex-wrap gap-1"></div>
       </div>
+      <div id="actions-box" class="hud-box">
+        <div class="font-bold mb-1">Actions</div>
+        <div id="actions-panel" class="flex flex-wrap gap-1"></div>
+      </div>
       <div id="dialogue" class="hud-box hidden"></div>
     </aside>
   </main>

--- a/main.js
+++ b/main.js
@@ -239,6 +239,7 @@ function renderRoom(loc) {
   buildNPCList(loc.npcs);
   buildMobList(loc.spawns);
   buildNodeList(loc.nodes);
+  buildActionsPanel(loc);
 }
 
 function enterRoom(id) {
@@ -430,6 +431,58 @@ function buildMobList(mobs) {
     btn.textContent = mob.name;
     btn.onclick = () => startCombat(id);
     list.append(btn);
+  });
+}
+
+function buildActionsPanel(loc) {
+  const panel = document.getElementById('actions-panel');
+  if (!panel) return;
+  panel.innerHTML = '';
+  const actions = [];
+  if ((loc.npcs || []).length) {
+    actions.push('talk');
+    const hasTrader = loc.npcs.some((nid) => {
+      const role = loader.get('npcs', nid)?.role?.toLowerCase() || '';
+      return role.includes('trader') || role.includes('merchant') || role.includes('barkeep');
+    });
+    if (hasTrader) actions.push('trade');
+  }
+  if ((loc.spawns || []).length) actions.push('attack');
+  if ((loc.nodes || []).length) actions.push('search');
+  actions.forEach((act) => {
+    const btn = document.createElement('button');
+    btn.className = 'btn text-xs';
+    btn.textContent = act.charAt(0).toUpperCase() + act.slice(1);
+    if (act === 'talk') {
+      btn.onclick = () => {
+        if (game.target && game.target.type === 'npc') talkToNpc(game.target.id);
+        else addLog('Select an NPC to talk to.');
+      };
+    } else if (act === 'attack') {
+      btn.onclick = () => {
+        if (game.target && game.target.type === 'mob') startCombat(game.target.id);
+        else if (game.target && game.target.type === 'npc') attackNpc(game.target.id);
+        else addLog('Select a valid target first.');
+      };
+    } else if (act === 'search') {
+      btn.onclick = () => {
+        if (game.target && game.target.type === 'node') {
+          addLog(`You search the ${game.target.name}.`);
+        } else {
+          addLog('Nothing to search here.');
+        }
+      };
+    } else if (act === 'trade') {
+      btn.onclick = () => {
+        if (game.target && game.target.type === 'npc') {
+          const npc = loader.get('npcs', game.target.id);
+          addLog(`You trade with ${npc?.name || game.target.id}.`);
+        } else {
+          addLog('Select a trader to trade with.');
+        }
+      };
+    }
+    panel.append(btn);
   });
 }
 


### PR DESCRIPTION
## Summary
- show an Actions box in the HUD
- display Talk/Attack/Search/Trade buttons based on current location

## Testing
- `npm install`
- `npx eslint .`


------
https://chatgpt.com/codex/tasks/task_e_6888010d9d20832fbd4d4443f1b8f8c2