### PR TITLE
Implement quest log with completion tracking

### DIFF
--- a/main.js
+++ b/main.js
@@ -14,7 +14,14 @@ function saveCharacter(p) {
 
 function loadCharacter() {
   const data = localStorage.getItem('player');
-  return data ? JSON.parse(data) : null;
+  if (!data) return null;
+  const p = JSON.parse(data);
+  p.completedQuests ||= [];
+  p.questProgress ||= {};
+  p.professions ||= [];
+  p.coins ||= { copper: 0, silver: 0, gold: 0 };
+  p.party ||= [];
+  return p;
 }
 let currentTargetBtn = null;
 
@@ -247,6 +254,7 @@ function enterRoom(id) {
   game.player.location = id;
   location.hash = id;
   renderRoom(loc);
+  checkQuestProgress('location', id);
   updateHUD();
 }
 
@@ -285,12 +293,14 @@ function attackRound() {
     loot.items.forEach((id) => {
       game.player.inventory.push(id);
       addLog(`You loot ${loader.data.items[id].name}.`);
+      checkQuestProgress('item', id);
     });
     if (loot.copper || loot.silver || loot.gold) {
       addLog(
         `You loot ${loot.gold}g ${loot.silver}s ${loot.copper}c.`
       );
     }
+    checkQuestProgress('kill', mob.id);
     updateHUD();
     return;
   }
@@ -331,6 +341,7 @@ function talkToNpc(id) {
   if (!npc) return;
   const line = npc.dialogue?.[0] || '...';
   addLog(`${npc.name} says: "${line}"`);
+  checkQuestProgress('talk', id);
   document.getElementById('dialogue').classList.add('hidden');
 }
 
@@ -360,8 +371,10 @@ function showNpcMenu(id) {
     btn.onclick = () => {
       if (window.confirm(`Accept quest "${q.name}"?`)) {
         game.player.activeQuests.push(qid);
+        game.player.questProgress[qid] = 0;
         addLog(`Quest accepted: ${q.name}`);
         dlg.classList.add('hidden');
+        buildQuestList();
       }
     };
     qdiv.append(btn);
@@ -496,10 +509,38 @@ function buildInventory() {
   inv.append(list);
 }
 
+function completeQuest(qid) {
+  const idx = game.player.activeQuests.indexOf(qid);
+  if (idx === -1) return;
+  game.player.activeQuests.splice(idx, 1);
+  game.player.completedQuests.push(qid);
+  delete game.player.questProgress[qid];
+  addLog(`Quest completed: ${loader.data.quests[qid].name}`);
+  buildQuestList();
+}
+
+function checkQuestProgress(type, id) {
+  game.player.activeQuests.forEach((qid) => {
+    const q = loader.data.quests[qid];
+    if (!q) return;
+    if (type === 'kill' && q.objective.kill === id) {
+      game.player.questProgress[qid] = (game.player.questProgress[qid] || 0) + 1;
+      if (game.player.questProgress[qid] >= q.objective.count) completeQuest(qid);
+    } else if (type === 'talk' && q.objective.talk === id) {
+      completeQuest(qid);
+    } else if (type === 'location' && q.objective.location === id) {
+      completeQuest(qid);
+    } else if (type === 'item' && q.objective.item === id) {
+      game.player.questProgress[qid] = (game.player.questProgress[qid] || 0) + 1;
+      if (game.player.questProgress[qid] >= q.objective.count) completeQuest(qid);
+    }
+  });
+}
+
 function buildQuestList() {
   const qpanel = document.getElementById('quests');
   qpanel.innerHTML = '<h2 class="text-lg mb-2">Active Quests</h2>';
-  const list = document.createElement('ul');
+  const activeList = document.createElement('ul');
   game.player.activeQuests.forEach((qid) => {
     const q = loader.data.quests[qid];
     if (!q) return;
@@ -509,9 +550,27 @@ function buildQuestList() {
     btn.textContent = q.name;
     btn.onclick = () => showQuestDetails(qid);
     li.append(btn);
-    list.append(li);
+    activeList.append(li);
   });
-  qpanel.append(list);
+  qpanel.append(activeList);
+
+  const compTitle = document.createElement('h2');
+  compTitle.className = 'text-lg mb-2 mt-4';
+  compTitle.textContent = 'Completed Quests';
+  qpanel.append(compTitle);
+  const compList = document.createElement('ul');
+  game.player.completedQuests.forEach((qid) => {
+    const q = loader.data.quests[qid];
+    if (!q) return;
+    const li = document.createElement('li');
+    const btn = document.createElement('button');
+    btn.className = 'underline text-slate-400 line-through';
+    btn.textContent = q.name;
+    btn.onclick = () => showQuestDetails(qid);
+    li.append(btn);
+    compList.append(li);
+  });
+  qpanel.append(compList);
   const details = document.createElement('div');
   details.id = 'quest-details';
   details.className = 'mt-4 text-sm';
@@ -623,6 +682,7 @@ function craftItem(prof, rid) {
   }
   game.player.inventory.push(recipe.result);
   addLog(`You craft ${loader.data.items[recipe.result].name}.`);
+  checkQuestProgress('item', recipe.result);
   buildInventory();
 }
 
@@ -802,7 +862,11 @@ function showCreateForm() {
       inventory: ['rusty_sword', 'healing_potion'],
       equipped: { weapon: 'rusty_sword' },
       activeQuests: ['welcome_to_realm'],
-      party: []
+      completedQuests: [],
+      questProgress: {},
+      party: [],
+      professions: [],
+      coins: { copper: 0, silver: 0, gold: 0 }
     };
     startGame(player);
   };


### PR DESCRIPTION
## Summary
- track completed quests and progress in player data
- auto-track progress for talking, killing mobs, traveling and collecting items
- add `completeQuest` and `checkQuestProgress` helpers
- refresh quest list when quests are accepted or completed
- show active and completed quests in the quest panel

## Testing
- `npx eslint .`

------
https://chatgpt.com/codex/tasks/task_e_68880120e6a8832fa1f25899fda4999a