### PR TITLE
Add zone info panel

### DIFF
--- a/index.html
+++ b/index.html
@@ -29,6 +29,11 @@
       <div id="target" class="hud-box">Target: —</div>
       <div id="party" class="hud-box">Party: —</div>
       <div id="currency" class="hud-box">Coins: 0g 0s 0c</div>
+      <div id="zone-panel" class="hud-box">
+        <div id="zone-name" class="font-bold mb-1">Zone</div>
+        <div id="zone-desc" class="text-xs mb-1"></div>
+        <div id="zone-exits" class="text-xs"></div>
+      </div>
       <div id="location-panel" class="hud-box">
         <div id="location-name" class="font-bold mb-1">Location</div>
         <div class="grid grid-cols-3 gap-1 place-items-center">

--- a/main.js
+++ b/main.js
@@ -190,6 +190,17 @@ function updateLocationPanel() {
   });
 }
 
+function updateZonePanel() {
+  const loc = loader.data.locations[game.player.location];
+  if (!loc) return;
+  document.getElementById('zone-name').textContent = loc.name;
+  document.getElementById('zone-desc').textContent = loc.description || '';
+  const exits = Object.values(loc.links || {})
+    .map((dest) => loader.data.locations[dest]?.name || dest)
+    .join(', ') || 'None';
+  document.getElementById('zone-exits').textContent = `Exits: ${exits}`;
+}
+
 function addLog(txt) {
   const div = document.createElement('div');
   div.textContent = txt;
@@ -287,11 +298,7 @@ function enterRoom(id) {
   checkQuestProgress('location', id);
   updateHUD();
   updateLocationPanel();
-}
-
-function move(dir) {
-  const dest = loader.data.locations[game.player.location].links[dir];
-  if (dest) enterRoom(dest);
+  updateZonePanel();
 }
 
 function move(dir) {


### PR DESCRIPTION
## Summary
- display zone name, description, and exits in a new HUD panel
- keep zone info updated when the player moves
- remove duplicate `move` function

## Testing
- `npm install`
- `npx eslint .`

------
https://chatgpt.com/codex/tasks/task_e_6888068408c8832f812a1fb858001785