### PR TITLE
Implement stat-based combat

### DIFF
--- a/main.js
+++ b/main.js
@@ -294,11 +294,6 @@ function move(dir) {
   if (dest) enterRoom(dest);
 }
 
-function move(dir) {
-  const dest = loader.data.locations[game.player.location].links[dir];
-  if (dest) enterRoom(dest);
-}
-
 function updatePlayersList() {
   const list = document.getElementById('player-list');
   if (!list) return;
@@ -311,18 +306,55 @@ function updatePlayersList() {
   });
 }
 
-function getWeaponDamage() {
-  const w = game.player.equipped.weapon;
-  return loader.data.items[w]?.damage || 1;
+/**
+ * Calculate an attack result using stats, gear and ability modifiers.
+ * @param {object} attacker
+ * @param {object} defender
+ * @param {object} [ability]
+ * @returns {{hit:boolean, crit:boolean, damage:number}}
+ */
+function calculateAttackResult(attacker, defender, ability = {}) {
+  const atkDex = attacker.stats?.dex ?? attacker.dex ?? attacker.level ?? 0;
+  const defDex = defender.stats?.dex ?? defender.dex ?? defender.level ?? 0;
+  const atkStr = attacker.stats?.str ?? attacker.str ?? attacker.level ?? 0;
+
+  let hitChance = 0.75 + atkDex * 0.01 - defDex * 0.005 + (ability.hitChance || 0);
+  hitChance = Math.min(Math.max(hitChance, 0.05), 0.95);
+  const hit = Math.random() < hitChance;
+
+  if (!hit) return { hit: false, crit: false, damage: 0 };
+
+  let weaponDamage = 1;
+  if (attacker.equipped?.weapon) {
+    weaponDamage = loader.data.items[attacker.equipped.weapon]?.damage || 1;
+  } else if (attacker.damage) {
+    weaponDamage = attacker.damage;
+  }
+
+  let damage = rand(weaponDamage) + atkStr + (ability.damage || 0);
+
+  let critChance = 0.05 + atkDex * 0.005 + (ability.critChance || 0);
+  critChance = Math.min(Math.max(critChance, 0), 0.5);
+  const crit = Math.random() < critChance;
+  if (crit) damage = Math.floor(damage * 1.5);
+
+  return { hit: true, crit, damage };
 }
 
 function attackRound() {
   const player = game.player;
   const mob = game.target;
   if (!mob) return;
-  const pdmg = rand(getWeaponDamage()) + player.stats.str;
-  mob.hp -= pdmg;
-  addLog(`You hit ${mob.name} for ${pdmg}.`);
+  const pres = calculateAttackResult(player, mob);
+  if (pres.hit) {
+    mob.hp -= pres.damage;
+    const pmsg = pres.crit
+      ? `Critical! You hit ${mob.name} for ${pres.damage}.`
+      : `You hit ${mob.name} for ${pres.damage}.`;
+    addLog(pmsg);
+  } else {
+    addLog(`You miss ${mob.name}.`);
+  }
   if (mob.hp <= 0) {
     addLog(`${mob.name} dies.`);
     clearInterval(game.combatTimer);
@@ -345,9 +377,16 @@ function attackRound() {
     updateHUD();
     return;
   }
-  const mdmg = rand(mob.damage);
-  player.hp -= mdmg;
-  addLog(`${mob.name} hits you for ${mdmg}.`);
+  const mres = calculateAttackResult(mob, player);
+  if (mres.hit) {
+    player.hp -= mres.damage;
+    const mmsg = mres.crit
+      ? `${mob.name} critically hits you for ${mres.damage}.`
+      : `${mob.name} hits you for ${mres.damage}.`;
+    addLog(mmsg);
+  } else {
+    addLog(`${mob.name} misses you.`);
+  }
   if (player.hp <= 0) {
     addLog('You have been slain!');
     clearInterval(game.combatTimer);


### PR DESCRIPTION
## Summary
- create `calculateAttackResult` to determine hit, crit, and damage using stats
- use the new attack result calculations in `attackRound`
- add npm deps for eslint

## Testing
- `npm install`
- `npx eslint .`

------
https://chatgpt.com/codex/tasks/task_e_688806ca86b4832fa7d604d8c0fc6052