### PR TITLE
Add mob drop tables and loot window

### DIFF
--- a/data/mobs.json
+++ b/data/mobs.json
@@ -4,20 +4,35 @@
     "level": 2,
     "hp": 30,
     "damage": 4,
-    "description": "A malfunctioning automaton covered in rust."
+    "description": "A malfunctioning automaton covered in rust.",
+    "drops": [
+      { "id": "iron_ore", "chance": 0.4 },
+      { "id": "cloth_scrap", "chance": 0.3 },
+      { "id": "rusty_sword", "chance": 0.1 }
+    ]
   },
   "bog_creeper": {
     "name": "Bog Creeper",
     "level": 3,
     "hp": 40,
     "damage": 5,
-    "description": "Slimy creature lurking in the bog."
+    "description": "Slimy creature lurking in the bog.",
+    "drops": [
+      { "id": "herb_leaf", "chance": 0.5 },
+      { "id": "cloth_scrap", "chance": 0.2 },
+      { "id": "healing_potion", "chance": 0.1 }
+    ]
   },
   "goblin_raider": {
     "name": "Goblin Raider",
     "level": 2,
     "hp": 25,
     "damage": 3,
-    "description": "Sneaky goblin looking for trouble."
+    "description": "Sneaky goblin looking for trouble.",
+    "drops": [
+      { "id": "wood_plank", "chance": 0.4 },
+      { "id": "rusty_sword", "chance": 0.2 },
+      { "id": "hunter_bow", "chance": 0.1 }
+    ]
   }
 }

--- a/index.html
+++ b/index.html
@@ -73,6 +73,7 @@
     <div id="craft" class="panel hidden bg-slate-800 p-4 rounded mb-4"></div>
     <div id="quests" class="panel hidden bg-slate-800 p-4 rounded mb-4"></div>
     <div id="chat-panel" class="panel hidden bg-slate-800 p-4 rounded mb-4"></div>
+    <div id="loot" class="panel hidden bg-slate-800 p-4 rounded mb-4"></div>
     <div class="text-center">
       <button id="close-overlay" class="btn">Close</button>
     </div>

--- a/main.js
+++ b/main.js
@@ -146,7 +146,11 @@ function dropLoot(mob) {
   loot.copper = rand(mob.level * 2);
   if (mob.level >= 5) loot.silver = rand(Math.floor(mob.level / 5));
   if (mob.level >= 20) loot.gold = rand(Math.floor(mob.level / 20));
-  if (Math.random() < 0.5) {
+  if (mob.drops) {
+    mob.drops.forEach((d) => {
+      if (Math.random() < d.chance) loot.items.push(d.id);
+    });
+  } else if (Math.random() < 0.5) {
     const list = Object.keys(loader.data.items).filter(
       (id) => loader.data.items[id].level <= mob.level
     );
@@ -201,6 +205,29 @@ function addChat(txt) {
   const div = document.createElement('div');
   div.textContent = txt;
   document.getElementById('chat-panel').append(div);
+}
+
+function showLoot(loot) {
+  const panel = document.getElementById('loot');
+  panel.innerHTML = '<h2 class="text-lg mb-2">Loot</h2>';
+  const list = document.createElement('ul');
+  loot.items.forEach((id) => {
+    const li = document.createElement('li');
+    li.textContent = loader.data.items[id]?.name || id;
+    list.append(li);
+  });
+  if (loot.gold || loot.silver || loot.copper) {
+    const li = document.createElement('li');
+    li.textContent = `${loot.gold}g ${loot.silver}s ${loot.copper}c`;
+    list.append(li);
+  }
+  panel.append(list);
+  const btn = document.createElement('button');
+  btn.className = 'btn mt-2';
+  btn.textContent = 'Close';
+  btn.onclick = () => document.getElementById('overlay').classList.add('hidden');
+  panel.append(btn);
+  showPanel('loot');
 }
 
 function showPanel(name) {
@@ -341,6 +368,7 @@ function attackRound() {
         `You loot ${loot.gold}g ${loot.silver}s ${loot.copper}c.`
       );
     }
+    showLoot(loot);
     checkQuestProgress('kill', mob.id);
     updateHUD();
     return;
@@ -357,7 +385,7 @@ function attackRound() {
 }
 
 function startCombat(mobId) {
-  game.target = { ...loader.data.mobs[mobId] };
+  game.target = { id: mobId, ...loader.data.mobs[mobId] };
   clearInterval(game.combatTimer);
   game.combatTimer = setInterval(attackRound, 2000);
   updateHUD();


### PR DESCRIPTION
## Summary
- add `drops` arrays to mobs
- display loot in a popup panel
- generate loot based on mob drop tables
- keep killed mob id for quest progress

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6888078010e0832fba18f58ff64c7cc0