### PR TITLE
Dynamic zone loading

### DIFF
--- a/data/loader.js
+++ b/data/loader.js
@@ -1,5 +1,6 @@
 export const loader = {
   data: {},
+  loadedZones: new Set(),
   async init() {
     const files = [
       'attributes',
@@ -9,7 +10,6 @@ export const loader = {
       'items',
       'spells',
       'quests',
-      'locations',
       'mobs',
       'npcs',
       'crafting'
@@ -20,6 +20,17 @@ export const loader = {
         this.data[name] = await res.json();
       })
     );
+    this.data.locations = {};
+    this.data.zones = {};
+  },
+  async loadZone(id) {
+    if (this.loadedZones.has(id)) return;
+    const res = await fetch(`data/zones/${id}.json`);
+    if (!res.ok) return;
+    const zone = await res.json();
+    Object.assign(this.data.locations, zone.locations);
+    this.data.zones[id] = zone;
+    this.loadedZones.add(id);
   },
   get(type, id) {
     return this.data[type]?.[id];

--- a/data/zones/dawn.json
+++ b/data/zones/dawn.json
@@ -1,0 +1,16 @@
+{
+  "locations": {
+    "dawn_isle_port": {
+      "name": "Dawn Isle Port",
+      "faction": "luminara",
+      "description": "A small harbor where boats depart for distant lands.",
+      "exits": [],
+      "links": {},
+      "boats": [
+        "undead_necropolis"
+      ],
+      "npcs": [],
+      "spawns": []
+    }
+  }
+}

--- a/data/zones/dwarf.json
+++ b/data/zones/dwarf.json
@@ -1,0 +1,32 @@
+{
+  "locations": {
+    "dwarf_fort_path": {
+      "name": "Stone Tunnel",
+      "faction": "neutral",
+      "description": "A well-carved tunnel slopes downward toward a dwarven stronghold.",
+      "exits": [
+        "neutral_crossroads",
+        "dwarf_fortress"
+      ],
+      "links": {
+        "crossroads": "neutral_crossroads",
+        "city": "dwarf_fortress"
+      },
+      "npcs": [],
+      "spawns": []
+    },
+    "dwarf_fortress": {
+      "name": "Dwarf Fortress",
+      "faction": "luminara",
+      "description": "Massive stone walls guard the halls of the stout folk.",
+      "exits": [
+        "dwarf_fort_path"
+      ],
+      "links": {
+        "road": "dwarf_fort_path"
+      },
+      "npcs": [],
+      "spawns": []
+    }
+  }
+}

--- a/data/zones/elven.json
+++ b/data/zones/elven.json
@@ -1,0 +1,32 @@
+{
+  "locations": {
+    "elven_glade_path": {
+      "name": "Elven Forest Road",
+      "faction": "neutral",
+      "description": "A serene path lined with ancient trees leading to the high elf city.",
+      "exits": [
+        "neutral_crossroads",
+        "elven_glade"
+      ],
+      "links": {
+        "crossroads": "neutral_crossroads",
+        "city": "elven_glade"
+      },
+      "npcs": [],
+      "spawns": []
+    },
+    "elven_glade": {
+      "name": "Elven Glade",
+      "faction": "luminara",
+      "description": "Homes built high in the trees sparkle with arcane light.",
+      "exits": [
+        "elven_glade_path"
+      ],
+      "links": {
+        "road": "elven_glade_path"
+      },
+      "npcs": [],
+      "spawns": []
+    }
+  }
+}

--- a/data/zones/gearhaven.json
+++ b/data/zones/gearhaven.json
@@ -1,0 +1,53 @@
+{
+  "locations": {
+    "gearhaven_plaza": {
+      "name": "Cogwheel Plaza",
+      "faction": "luminara",
+      "description": "Steam hisses from pipes and gears grind beneath your feet. Merchants shout over the clatter while travelers mingle in the plaza.",
+      "exits": [
+        "n",
+        "e",
+        "s"
+      ],
+      "links": {
+        "n": "gearhaven_workshop",
+        "e": "neutral_crossroads",
+        "s": "shadowfen_camp"
+      },
+      "npcs": [
+        "thaldo_tinkerer",
+        "gilda_crafter",
+        "rogar_trainer",
+        "belena_trainer",
+        "bard_npc",
+        "druid_npc",
+        "joran_barkeep"
+      ],
+      "spawns": [
+        "rogue_clockwork"
+      ],
+      "nodes": [
+        "gearhaven_sign"
+      ]
+    },
+    "gearhaven_workshop": {
+      "name": "Gearhaven Workshop",
+      "faction": "luminara",
+      "description": "Inventors toil with strange contraptions here, the air thick with the scent of oil and magic.",
+      "exits": [
+        "s"
+      ],
+      "links": {
+        "s": "gearhaven_plaza"
+      },
+      "npcs": [
+        "thaldo_tinkerer",
+        "gilda_crafter"
+      ],
+      "spawns": [],
+      "nodes": [
+        "workshop_anvil"
+      ]
+    }
+  }
+}

--- a/data/zones/gnome.json
+++ b/data/zones/gnome.json
@@ -1,0 +1,32 @@
+{
+  "locations": {
+    "gnome_burrow_path": {
+      "name": "Gnome Tunnel",
+      "faction": "neutral",
+      "description": "A cramped tunnel lit by flickering lanterns.",
+      "exits": [
+        "neutral_crossroads",
+        "gnome_burrow"
+      ],
+      "links": {
+        "crossroads": "neutral_crossroads",
+        "city": "gnome_burrow"
+      },
+      "npcs": [],
+      "spawns": []
+    },
+    "gnome_burrow": {
+      "name": "Gnome Burrow",
+      "faction": "luminara",
+      "description": "A maze of cozy burrows bustling with tinkering gnomes.",
+      "exits": [
+        "gnome_burrow_path"
+      ],
+      "links": {
+        "road": "gnome_burrow_path"
+      },
+      "npcs": [],
+      "spawns": []
+    }
+  }
+}

--- a/data/zones/neutral.json
+++ b/data/zones/neutral.json
@@ -1,0 +1,30 @@
+{
+  "locations": {
+    "neutral_crossroads": {
+      "name": "Crossroads",
+      "faction": "neutral",
+      "description": "A dusty intersection where caravans pause and news from all factions is traded.",
+      "exits": [
+        "gearhaven_plaza",
+        "elven_glade_path",
+        "dwarf_fort_path",
+        "gnome_burrow_path",
+        "orc_stronghold_path",
+        "undead_trail"
+      ],
+      "links": {
+        "west": "gearhaven_plaza",
+        "elven_path": "elven_glade_path",
+        "dwarf_path": "dwarf_fort_path",
+        "gnome_path": "gnome_burrow_path",
+        "orc_path": "orc_stronghold_path",
+        "undead_path": "undead_trail"
+      },
+      "npcs": [
+        "ranger_npc",
+        "traveling_merchant"
+      ],
+      "spawns": []
+    }
+  }
+}

--- a/data/zones/orc.json
+++ b/data/zones/orc.json
@@ -1,0 +1,32 @@
+{
+  "locations": {
+    "orc_stronghold_path": {
+      "name": "Blasted Trail",
+      "faction": "neutral",
+      "description": "A rough trail littered with bones leading to the orc stronghold.",
+      "exits": [
+        "neutral_crossroads",
+        "orc_stronghold"
+      ],
+      "links": {
+        "crossroads": "neutral_crossroads",
+        "city": "orc_stronghold"
+      },
+      "npcs": [],
+      "spawns": []
+    },
+    "orc_stronghold": {
+      "name": "Orc Stronghold",
+      "faction": "umbra",
+      "description": "A fortified camp echoing with war drums.",
+      "exits": [
+        "orc_stronghold_path"
+      ],
+      "links": {
+        "road": "orc_stronghold_path"
+      },
+      "npcs": [],
+      "spawns": []
+    }
+  }
+}

--- a/data/zones/shadowfen.json
+++ b/data/zones/shadowfen.json
@@ -1,0 +1,45 @@
+{
+  "locations": {
+    "shadowfen_camp": {
+      "name": "Shadowfen Camp",
+      "faction": "umbra",
+      "description": "A dark encampment surrounded by murky waters where warriors of Umbra sharpen their blades.",
+      "exits": [
+        "n",
+        "e"
+      ],
+      "links": {
+        "n": "gearhaven_plaza",
+        "e": "shadowfen_bog"
+      },
+      "npcs": [
+        "bog_hunter",
+        "shadra_shaman",
+        "gruk_trainer",
+        "morga_shadow",
+        "drezz_smith"
+      ],
+      "spawns": [
+        "goblin_raider"
+      ]
+    },
+    "shadowfen_bog": {
+      "name": "Shadowfen Bog",
+      "faction": "umbra",
+      "description": "Thick mist blankets the soggy ground and the croak of unseen creatures echoes all around.",
+      "exits": [
+        "w"
+      ],
+      "links": {
+        "w": "shadowfen_camp"
+      },
+      "npcs": [],
+      "spawns": [
+        "bog_creeper"
+      ],
+      "nodes": [
+        "bog_stone"
+      ]
+    }
+  }
+}

--- a/data/zones/undead.json
+++ b/data/zones/undead.json
@@ -1,0 +1,35 @@
+{
+  "locations": {
+    "undead_trail": {
+      "name": "Forsaken Path",
+      "faction": "neutral",
+      "description": "A chilling road lined with the remnants of battles long past.",
+      "exits": [
+        "neutral_crossroads",
+        "undead_necropolis"
+      ],
+      "links": {
+        "crossroads": "neutral_crossroads",
+        "city": "undead_necropolis"
+      },
+      "npcs": [],
+      "spawns": []
+    },
+    "undead_necropolis": {
+      "name": "Undead Necropolis",
+      "faction": "umbra",
+      "description": "Crumbling mausoleums rise from dark soil under a perpetual gloom.",
+      "exits": [
+        "undead_trail"
+      ],
+      "links": {
+        "road": "undead_trail"
+      },
+      "boats": [
+        "dawn_isle_port"
+      ],
+      "npcs": [],
+      "spawns": []
+    }
+  }
+}

--- a/main.js
+++ b/main.js
@@ -35,6 +35,10 @@ function rand(max) {
   return Math.floor(Math.random() * max) + 1;
 }
 
+function zoneFromLocation(id) {
+  return id.split('_')[0];
+}
+
 function selectTarget(type, id, btn) {
   if (currentTargetBtn) currentTargetBtn.classList.remove('targeted');
   currentTargetBtn = btn || null;
@@ -210,23 +214,6 @@ function buildMoveControls(loc) {
   });
 }
 
-function updateMovementButtons() {
-  const loc = loader.data.locations[game.player.location];
-  const container = document.getElementById('move-controls');
-  if (!loc || !container) return;
-  container.innerHTML = '';
-  const names = { n: 'North', e: 'East', s: 'South', w: 'West' };
-  Object.entries(names).forEach(([dir, label]) => {
-    if (loc.links?.[dir]) {
-      const btn = document.createElement('button');
-      btn.className = 'move-btn';
-      btn.dataset.dir = dir;
-      btn.textContent = label;
-      btn.onclick = () => move(dir);
-      container.append(btn);
-    }
-  });
-}
 
 function addLog(txt) {
   const div = document.createElement('div');
@@ -339,7 +326,9 @@ function renderRoom(loc) {
   buildActionsPanel(loc);
 }
 
-function enterRoom(id) {
+async function enterRoom(id) {
+  const zone = zoneFromLocation(id);
+  await loader.loadZone(zone);
   const loc = loader.data.locations[id];
   if (!loc) return;
   game.player.location = id;
@@ -350,9 +339,9 @@ function enterRoom(id) {
   updateLocationPanel();
 }
 
-function move(dir) {
+async function move(dir) {
   const dest = loader.data.locations[game.player.location].links[dir];
-  if (dest) enterRoom(dest);
+  if (dest) await enterRoom(dest);
 }
 
 
@@ -1065,7 +1054,7 @@ function populateSelect(id, data) {
   });
 }
 
-function startGame(player) {
+async function startGame(player) {
   game.player = player;
   document.getElementById('create-overlay').classList.add('hidden');
   saveCharacter(player);
@@ -1074,7 +1063,7 @@ function startGame(player) {
   bindUI();
   buildHotbar();
   const start = location.hash.slice(1) || game.player.location;
-  enterRoom(start);
+  await enterRoom(start);
 }
 
 function showCreateForm() {
@@ -1139,7 +1128,7 @@ export async function init() {
   bindUI();
   const saved = loadCharacter();
   if (saved) {
-    startGame(saved);
+    await startGame(saved);
   } else {
     showCreateForm();
   }


### PR DESCRIPTION
## Summary
- split locations into zone JSON files
- add `loadZone` helper and track loaded zones
- load zone data when entering a room

## Testing
- `npm install`
- `npx eslint .`

------
https://chatgpt.com/codex/tasks/task_e_68880bb232dc832f8edc1ccd09903c2a