### PR TITLE
Implement quest stages and sidebar

### DIFF
--- a/data/loader.js
+++ b/data/loader.js
@@ -8,7 +8,6 @@ export const loader = {
       'deities',
       'items',
       'spells',
-      'quests',
       'locations',
       'mobs',
       'npcs',
@@ -18,6 +17,16 @@ export const loader = {
       files.map(async (name) => {
         const res = await fetch(`data/${name}.json`);
         this.data[name] = await res.json();
+      })
+    );
+    // Load quests from individual files in data/quests
+    const idxRes = await fetch('data/quests/index.json');
+    const list = await idxRes.json();
+    this.data.quests = {};
+    await Promise.all(
+      list.map(async (id) => {
+        const qRes = await fetch(`data/quests/${id}.json`);
+        this.data.quests[id] = await qRes.json();
       })
     );
   },

--- a/data/quests/clear_the_bog.json
+++ b/data/quests/clear_the_bog.json
@@ -1,0 +1,17 @@
+{
+  "name": "Clear the Bog",
+  "giver": "bog_hunter",
+  "zones": ["shadowfen"],
+  "triggers": [],
+  "stages": [
+    {
+      "description": "Slay 2 bog creepers in Shadowfen.",
+      "objective": { "kill": "bog_creeper", "count": 2 }
+    },
+    {
+      "description": "Report back to the hunter.",
+      "objective": { "talk": "bog_hunter" }
+    }
+  ],
+  "rewards": { "xp": 120, "items": ["mana_potion"] }
+}

--- a/data/quests/fix_the_pipes.json
+++ b/data/quests/fix_the_pipes.json
@@ -1,0 +1,17 @@
+{
+  "name": "Fix the Pipes",
+  "giver": "thaldo_tinkerer",
+  "zones": ["gearhaven"],
+  "triggers": ["collect_parts"],
+  "stages": [
+    {
+      "description": "Collect 3 pipe parts from rogue clockworks.",
+      "objective": { "item": "pipe_part", "count": 3 }
+    },
+    {
+      "description": "Return to Thaldo.",
+      "objective": { "talk": "thaldo_tinkerer" }
+    }
+  ],
+  "rewards": { "xp": 100, "items": ["healing_potion"] }
+}

--- a/data/quests/gather_herbs.json
+++ b/data/quests/gather_herbs.json
@@ -1,0 +1,16 @@
+{
+  "name": "Gather Herbs",
+  "giver": "druid_npc",
+  "zones": ["gearhaven"],
+  "stages": [
+    {
+      "description": "Collect 5 healing herbs around Gearhaven.",
+      "objective": { "item": "healing_herb", "count": 5 }
+    },
+    {
+      "description": "Bring the herbs to the druid.",
+      "objective": { "talk": "druid_npc" }
+    }
+  ],
+  "rewards": { "xp": 80, "items": ["regrowth_scroll"] }
+}

--- a/data/quests/index.json
+++ b/data/quests/index.json
@@ -1,0 +1,8 @@
+[
+  "fix_the_pipes",
+  "clear_the_bog",
+  "lost_lute",
+  "gather_herbs",
+  "scout_camp",
+  "welcome_to_realm"
+]

--- a/data/quests/lost_lute.json
+++ b/data/quests/lost_lute.json
@@ -1,0 +1,16 @@
+{
+  "name": "Lost Lute",
+  "giver": "bard_npc",
+  "zones": ["gearhaven"],
+  "stages": [
+    {
+      "description": "Retrieve the bard's lost lute from goblin raiders.",
+      "objective": { "item": "bard_lute", "count": 1 }
+    },
+    {
+      "description": "Return the lute to the bard.",
+      "objective": { "talk": "bard_npc" }
+    }
+  ],
+  "rewards": { "xp": 150, "items": ["bard_lute"] }
+}

--- a/data/quests/scout_camp.json
+++ b/data/quests/scout_camp.json
@@ -1,0 +1,16 @@
+{
+  "name": "Scout the Camp",
+  "giver": "ranger_npc",
+  "zones": ["goblin_forest"],
+  "stages": [
+    {
+      "description": "Investigate the goblin camp.",
+      "objective": { "location": "goblin_camp" }
+    },
+    {
+      "description": "Report your findings to the ranger.",
+      "objective": { "talk": "ranger_npc" }
+    }
+  ],
+  "rewards": { "xp": 70 }
+}

--- a/data/quests/welcome_to_realm.json
+++ b/data/quests/welcome_to_realm.json
@@ -1,0 +1,12 @@
+{
+  "name": "Welcome to Twilight Realms",
+  "giver": "thaldo_tinkerer",
+  "zones": ["gearhaven"],
+  "stages": [
+    {
+      "description": "Speak with Thaldo to learn the basics.",
+      "objective": { "talk": "thaldo_tinkerer" }
+    }
+  ],
+  "rewards": { "xp": 50, "items": ["rusty_sword"] }
+}

--- a/index.html
+++ b/index.html
@@ -27,10 +27,9 @@
 
   <!-- Main layout -->
 
-  <main class="grow grid md:grid-cols-[16rem_1fr_16rem] gap-2 p-2 overflow-hidden">
+  <main class="grow grid md:grid-cols-[16rem_1fr_16rem_16rem] gap-2 p-2 overflow-hidden">
     <aside id="left-panel" class="bg-slate-800 p-3 rounded flex flex-col gap-2 overflow-y-auto">
       <div id="inv" class="hud-box"></div>
-      <div id="quests" class="hud-box flex-grow overflow-y-auto"></div>
     </aside>
 
     <div class="flex flex-col gap-2 overflow-hidden">
@@ -78,6 +77,9 @@
       <div id="dialogue" class="hud-box hidden"></div>
       <div id="chat-panel" class="hud-box flex-grow overflow-y-auto"></div>
       <div id="minimap" class="hud-box h-40"></div>
+    </aside>
+    <aside id="quest-sidebar" class="bg-slate-800 p-3 rounded flex flex-col gap-2 overflow-y-auto">
+      <div id="quests" class="hud-box flex-grow overflow-y-auto"></div>
     </aside>
   </main>
   <!-- Overlay panels -->

--- a/main.js
+++ b/main.js
@@ -210,23 +210,6 @@ function buildMoveControls(loc) {
   });
 }
 
-function updateMovementButtons() {
-  const loc = loader.data.locations[game.player.location];
-  const container = document.getElementById('move-controls');
-  if (!loc || !container) return;
-  container.innerHTML = '';
-  const names = { n: 'North', e: 'East', s: 'South', w: 'West' };
-  Object.entries(names).forEach(([dir, label]) => {
-    if (loc.links?.[dir]) {
-      const btn = document.createElement('button');
-      btn.className = 'move-btn';
-      btn.dataset.dir = dir;
-      btn.textContent = label;
-      btn.onclick = () => move(dir);
-      container.append(btn);
-    }
-  });
-}
 
 function addLog(txt) {
   const div = document.createElement('div');
@@ -514,7 +497,7 @@ function showNpcMenu(id) {
     btn.onclick = () => {
       if (window.confirm(`Accept quest "${q.name}"?`)) {
         game.player.activeQuests.push(qid);
-        game.player.questProgress[qid] = 0;
+        game.player.questProgress[qid] = { stage: 0, count: 0 };
         addLog(`Quest accepted: ${q.name}`);
         dlg.classList.add('hidden');
         buildQuestList();
@@ -754,20 +737,37 @@ function completeQuest(qid) {
   buildQuestList();
 }
 
+function advanceQuestStage(qid) {
+  const q = loader.data.quests[qid];
+  const prog = game.player.questProgress[qid];
+  if (!q || !prog) return;
+  if (prog.stage < q.stages.length - 1) {
+    prog.stage += 1;
+    prog.count = 0;
+    addLog(`Quest updated: ${q.name} - ${q.stages[prog.stage].description}`);
+    buildQuestList();
+  } else {
+    completeQuest(qid);
+  }
+}
+
 function checkQuestProgress(type, id) {
   game.player.activeQuests.forEach((qid) => {
     const q = loader.data.quests[qid];
-    if (!q) return;
-    if (type === 'kill' && q.objective.kill === id) {
-      game.player.questProgress[qid] = (game.player.questProgress[qid] || 0) + 1;
-      if (game.player.questProgress[qid] >= q.objective.count) completeQuest(qid);
-    } else if (type === 'talk' && q.objective.talk === id) {
-      completeQuest(qid);
-    } else if (type === 'location' && q.objective.location === id) {
-      completeQuest(qid);
-    } else if (type === 'item' && q.objective.item === id) {
-      game.player.questProgress[qid] = (game.player.questProgress[qid] || 0) + 1;
-      if (game.player.questProgress[qid] >= q.objective.count) completeQuest(qid);
+    const prog = game.player.questProgress[qid];
+    if (!q || !prog) return;
+    const stage = q.stages[prog.stage];
+    const obj = stage.objective;
+    if (type === 'kill' && obj.kill === id) {
+      prog.count = (prog.count || 0) + 1;
+      if (prog.count >= (obj.count || 1)) advanceQuestStage(qid);
+    } else if (type === 'talk' && obj.talk === id) {
+      advanceQuestStage(qid);
+    } else if (type === 'location' && obj.location === id) {
+      advanceQuestStage(qid);
+    } else if (type === 'item' && obj.item === id) {
+      prog.count = (prog.count || 0) + 1;
+      if (prog.count >= (obj.count || 1)) advanceQuestStage(qid);
     }
   });
 }
@@ -813,33 +813,45 @@ function buildQuestList() {
   qpanel.append(details);
 }
 
+function formatObjective(obj) {
+  if (obj.item) {
+    const itm = loader.data.items[obj.item]?.name || obj.item;
+    return `Collect ${obj.count || 1} ${itm}`;
+  }
+  if (obj.kill) {
+    const mob = loader.data.mobs[obj.kill]?.name || obj.kill;
+    return `Defeat ${obj.count || 1} ${mob}`;
+  }
+  if (obj.talk) {
+    const npc = loader.get('npcs', obj.talk)?.name || obj.talk;
+    return `Speak with ${npc}`;
+  }
+  if (obj.location) {
+    const loc = loader.data.locations[obj.location]?.name || obj.location;
+    return `Travel to ${loc}`;
+  }
+  return '';
+}
+
 function showQuestDetails(qid) {
   const q = loader.data.quests[qid];
   if (!q) return;
   const giver = loader.get('npcs', q.giver)?.name || q.giver;
-  let objective = '';
-  if (q.objective.item) {
-    const itm = loader.data.items[q.objective.item]?.name || q.objective.item;
-    objective = `Collect ${q.objective.count} ${itm}`;
-  } else if (q.objective.kill) {
-    const mob = loader.data.mobs[q.objective.kill]?.name || q.objective.kill;
-    objective = `Defeat ${q.objective.count} ${mob}`;
-  } else if (q.objective.talk) {
-    const npc = loader.get('npcs', q.objective.talk)?.name || q.objective.talk;
-    objective = `Speak with ${npc}`;
-  } else if (q.objective.location) {
-    const loc =
-      loader.data.locations[q.objective.location]?.name || q.objective.location;
-    objective = `Travel to ${loc}`;
-  }
+  const prog = game.player.questProgress[qid];
+  const stageIdx = game.player.completedQuests.includes(qid)
+    ? q.stages.length - 1
+    : prog?.stage || 0;
+  const stage = q.stages[stageIdx];
+  const objective = formatObjective(stage.objective);
   const rewards = [];
-  if (q.reward.xp) rewards.push(`${q.reward.xp} XP`);
-  if (q.reward.item)
-    rewards.push(loader.data.items[q.reward.item]?.name || q.reward.item);
+  if (q.rewards?.xp) rewards.push(`${q.rewards.xp} XP`);
+  (q.rewards?.items || []).forEach((i) =>
+    rewards.push(loader.data.items[i]?.name || i)
+  );
   const details = document.getElementById('quest-details');
   details.innerHTML = `
     <h3 class="text-md font-bold mb-1">${q.name}</h3>
-    <p class="mb-1">${q.description}</p>
+    <p class="mb-1">${stage.description}</p>
     <p class="mb-1"><strong>Objective:</strong> ${objective}</p>
     <p class="mb-1"><strong>Reward:</strong> ${rewards.join(', ') || 'None'}</p>
     <p class="mb-1"><strong>Turn in:</strong> ${giver}</p>
@@ -1073,6 +1085,12 @@ function startGame(player) {
   updatePlayersList();
   bindUI();
   buildHotbar();
+  game.player.activeQuests.forEach((qid) => {
+    if (!game.player.questProgress[qid]) {
+      game.player.questProgress[qid] = { stage: 0, count: 0 };
+    }
+  });
+  buildQuestList();
   const start = location.hash.slice(1) || game.player.location;
   enterRoom(start);
 }


### PR DESCRIPTION
## Summary
- support quest data loaded from `data/quests/*.json`
- restructure quest panel into dedicated sidebar
- track quest progress by stage
- display quest details with current objective

## Testing
- `npx eslint .`

------
https://chatgpt.com/codex/tasks/task_e_68880be81084832fa37687087d881726