### PR TITLE
Add stat based combat calculations

### DIFF
--- a/data/items.json
+++ b/data/items.json
@@ -3,6 +3,7 @@
     "name": "Rusty Sword",
     "level": 1,
     "damage": 4,
+    "str": 1,
     "slot": "weapon",
     "description": "An old sword with a dull blade."
   },
@@ -10,6 +11,7 @@
     "name": "Leather Armor",
     "level": 1,
     "armor": 2,
+    "dex": 1,
     "slot": "chest",
     "description": "Provides minimal protection."
   },
@@ -36,6 +38,7 @@
     "name": "Hunter Bow",
     "level": 1,
     "damage": 3,
+    "dex": 2,
     "slot": "weapon",
     "description": "Simple bow favored by rangers."
   },

--- a/data/mobs.json
+++ b/data/mobs.json
@@ -4,6 +4,9 @@
     "level": 2,
     "hp": 30,
     "damage": 4,
+    "str": 6,
+    "dex": 4,
+    "int": 2,
     "description": "A malfunctioning automaton covered in rust.",
     "drops": [
       { "id": "iron_ore", "chance": 0.4 },
@@ -16,6 +19,9 @@
     "level": 3,
     "hp": 40,
     "damage": 5,
+    "str": 7,
+    "dex": 5,
+    "int": 2,
     "description": "Slimy creature lurking in the bog.",
     "drops": [
       { "id": "herb_leaf", "chance": 0.5 },
@@ -28,6 +34,9 @@
     "level": 2,
     "hp": 25,
     "damage": 3,
+    "str": 5,
+    "dex": 6,
+    "int": 2,
     "description": "Sneaky goblin looking for trouble.",
     "drops": [
       { "id": "wood_plank", "chance": 0.4 },

--- a/main.js
+++ b/main.js
@@ -35,6 +35,69 @@ function rand(max) {
   return Math.floor(Math.random() * max) + 1;
 }
 
+function getEffectiveStats(ent) {
+  const stats = { str: 0, dex: 0, int: 0 };
+  if (ent.stats) {
+    stats.str += ent.stats.str || 0;
+    stats.dex += ent.stats.dex || 0;
+    stats.int += ent.stats.int || 0;
+  }
+  if (ent.equipped) {
+    Object.values(ent.equipped).forEach((id) => {
+      const item = loader.data.items[id];
+      if (item) {
+        stats.str += item.str || 0;
+        stats.dex += item.dex || 0;
+        stats.int += item.int || 0;
+      }
+    });
+  }
+  return stats;
+}
+
+function getArmor(ent) {
+  let armor = ent.armor || 0;
+  if (ent.equipped) {
+    Object.values(ent.equipped).forEach((id) => {
+      const item = loader.data.items[id];
+      if (item && item.armor) armor += item.armor;
+    });
+  }
+  return armor;
+}
+
+function getWeaponDamage(ent) {
+  if (ent.damage) return ent.damage;
+  let dmg = 1;
+  if (ent.equipped && ent.equipped.weapon) {
+    dmg += loader.data.items[ent.equipped.weapon]?.damage || 0;
+  }
+  return dmg;
+}
+
+function resolveAttack(attacker, defender, ability = {}) {
+  const atk = getEffectiveStats(attacker);
+  const def = getEffectiveStats(defender);
+
+  const dodgeChance = Math.min(30, def.dex * 0.5);
+  if (Math.random() * 100 < dodgeChance) return { dodge: true };
+
+  const hitChance = 70 + (atk.dex - def.dex);
+  if (Math.random() * 100 >= hitChance) return { miss: true };
+
+  const critChance = 5 + atk.dex * 0.2;
+  const crit = Math.random() * 100 < critChance;
+
+  let dmg = getWeaponDamage(attacker);
+  if (ability.damage) dmg += ability.damage + Math.floor(atk.int / 2);
+  dmg += Math.floor(atk.str / 2);
+  if (crit) dmg *= 1.5;
+  dmg -= getArmor(defender);
+  if (dmg < 0) dmg = 0;
+
+  return { damage: Math.floor(dmg), crit };
+}
+
 function selectTarget(type, id, btn) {
   if (currentTargetBtn) currentTargetBtn.classList.remove('targeted');
   currentTargetBtn = btn || null;
@@ -210,23 +273,6 @@ function buildMoveControls(loc) {
   });
 }
 
-function updateMovementButtons() {
-  const loc = loader.data.locations[game.player.location];
-  const container = document.getElementById('move-controls');
-  if (!loc || !container) return;
-  container.innerHTML = '';
-  const names = { n: 'North', e: 'East', s: 'South', w: 'West' };
-  Object.entries(names).forEach(([dir, label]) => {
-    if (loc.links?.[dir]) {
-      const btn = document.createElement('button');
-      btn.className = 'move-btn';
-      btn.dataset.dir = dir;
-      btn.textContent = label;
-      btn.onclick = () => move(dir);
-      container.append(btn);
-    }
-  });
-}
 
 function addLog(txt) {
   const div = document.createElement('div');
@@ -414,9 +460,16 @@ function endCombat(win) {
 
 function enemyAttack() {
   const mob = game.target;
-  const dmg = rand(mob.damage);
-  game.player.hp -= dmg;
-  addCombatLog(`${mob.name} hits you for ${dmg}.`);
+  const res = resolveAttack(mob, game.player);
+  if (res.dodge) {
+    addCombatLog('You dodge the attack.');
+  } else if (res.miss) {
+    addCombatLog(`${mob.name} misses.`);
+  } else {
+    game.player.hp -= res.damage;
+    const crit = res.crit ? ' CRIT!' : '';
+    addCombatLog(`${mob.name} hits you for ${res.damage}.${crit}`);
+  }
   if (game.player.hp <= 0) {
     addCombatLog('You have been defeated!');
     endCombat(false);
@@ -431,9 +484,16 @@ function useAbility(id) {
   if (!spell) return;
   addCombatLog(`You use ${spell.name}.`);
   if (spell.damage) {
-    const dmg = rand(spell.damage);
-    game.target.hp -= dmg;
-    addCombatLog(`You deal ${dmg} damage.`);
+    const res = resolveAttack(game.player, game.target, spell);
+    if (res.dodge) {
+      addCombatLog(`${game.target.name} dodges your attack.`);
+    } else if (res.miss) {
+      addCombatLog('You miss.');
+    } else {
+      game.target.hp -= res.damage;
+      const crit = res.crit ? ' CRIT!' : '';
+      addCombatLog(`You deal ${res.damage} damage.${crit}`);
+    }
   }
   if (spell.heal) {
     game.player.hp = Math.min(game.player.maxHp, game.player.hp + spell.heal);


### PR DESCRIPTION
## Summary
- implement gear bonuses and stat based attack calculations
- give sample items STR/DEX bonuses
- add STR/DEX/INT stats to mobs
- rework combat functions to use stats
- remove unused movement buttons

## Testing
- `npm install`
- `npx eslint .`


------
https://chatgpt.com/codex/tasks/task_e_68880bef9ea0832f8f1e765ad551aa70