### PR TITLE
Add map graph visualization

### DIFF
--- a/data/map.json
+++ b/data/map.json
@@ -1,0 +1,64 @@
+{
+  "gearhaven_plaza": {
+    "n": "gearhaven_workshop",
+    "e": "neutral_crossroads",
+    "s": "shadowfen_camp"
+  },
+  "gearhaven_workshop": {
+    "s": "gearhaven_plaza"
+  },
+  "shadowfen_camp": {
+    "n": "gearhaven_plaza",
+    "e": "shadowfen_bog"
+  },
+  "shadowfen_bog": {
+    "w": "shadowfen_camp"
+  },
+  "neutral_crossroads": {
+    "west": "gearhaven_plaza",
+    "elven_path": "elven_glade_path",
+    "dwarf_path": "dwarf_fort_path",
+    "gnome_path": "gnome_burrow_path",
+    "orc_path": "orc_stronghold_path",
+    "undead_path": "undead_trail"
+  },
+  "elven_glade_path": {
+    "crossroads": "neutral_crossroads",
+    "city": "elven_glade"
+  },
+  "elven_glade": {
+    "road": "elven_glade_path"
+  },
+  "dwarf_fort_path": {
+    "crossroads": "neutral_crossroads",
+    "city": "dwarf_fortress"
+  },
+  "dwarf_fortress": {
+    "road": "dwarf_fort_path"
+  },
+  "gnome_burrow_path": {
+    "crossroads": "neutral_crossroads",
+    "city": "gnome_burrow"
+  },
+  "gnome_burrow": {
+    "road": "gnome_burrow_path"
+  },
+  "orc_stronghold_path": {
+    "crossroads": "neutral_crossroads",
+    "city": "orc_stronghold"
+  },
+  "orc_stronghold": {
+    "road": "orc_stronghold_path"
+  },
+  "undead_trail": {
+    "crossroads": "neutral_crossroads",
+    "city": "undead_necropolis"
+  },
+  "undead_necropolis": {
+    "road": "undead_trail",
+    "boat_dawn_isle_port": "dawn_isle_port"
+  },
+  "dawn_isle_port": {
+    "boat_undead_necropolis": "undead_necropolis"
+  }
+}

--- a/index.html
+++ b/index.html
@@ -6,6 +6,7 @@
   <title>Twilight Realms</title>
   <!-- Tailwind via CDN -->
   <script src="https://cdn.tailwindcss.com"></script>
+  <script src="https://unpkg.com/d3@7/dist/d3.min.js"></script>
   <link rel="stylesheet" href="style.css">
 </head>
 <body class="h-full bg-slate-900 text-slate-200 flex flex-col">
@@ -14,6 +15,7 @@
     <h1 class="text-xl font-bold">Twilight Realms</h1>
     <nav class="flex gap-2 text-sm">
       <button data-panel="map" class="btn">Map</button>
+      <button data-panel="graph" class="btn">Graph</button>
       <button data-panel="craft" class="btn">Craft</button>
     </nav>
   </header>
@@ -83,6 +85,7 @@
   <!-- Overlay panels -->
   <div id="overlay" class="hidden fixed inset-0 bg-black/70 p-4 overflow-auto">
     <div id="map" class="panel hidden bg-slate-800 p-4 rounded mb-4"></div>
+    <div id="graph" class="panel hidden bg-slate-800 p-4 rounded mb-4"></div>
     <div id="craft" class="panel hidden bg-slate-800 p-4 rounded mb-4"></div>
     <div class="text-center">
       <button id="close-overlay" class="btn">Close</button>

--- a/main.js
+++ b/main.js
@@ -281,6 +281,7 @@ function showPanel(name) {
   document.getElementById(name).classList.remove('hidden');
   if (name === 'quests') buildQuestList();
   if (name === 'map') buildMap();
+  if (name === 'graph') buildGraph();
   if (name === 'craft') buildCraftPanel();
 }
 
@@ -890,6 +891,73 @@ function buildMap() {
     list.append(li);
   });
   map.append(list);
+}
+
+async function buildGraph() {
+  const panel = document.getElementById('graph');
+  panel.innerHTML = '<h2 class="text-lg mb-2">World Graph</h2><svg width="600" height="600"></svg>';
+  const res = await fetch('data/map.json');
+  const graph = await res.json();
+  const nodes = Object.keys(graph).map((id) => ({ id, name: loader.data.locations[id]?.name || id }));
+  const links = [];
+  Object.entries(graph).forEach(([src, exits]) => {
+    Object.values(exits).forEach((dest) => links.push({ source: src, target: dest }));
+  });
+  const svg = d3.select(panel.querySelector('svg'));
+  const sim = d3
+    .forceSimulation(nodes)
+    .force('link', d3.forceLink(links).id((d) => d.id).distance(80))
+    .force('charge', d3.forceManyBody().strength(-200))
+    .force('center', d3.forceCenter(300, 300));
+  const link = svg
+    .selectAll('line')
+    .data(links)
+    .enter()
+    .append('line')
+    .attr('stroke', '#999');
+  const node = svg
+    .selectAll('circle')
+    .data(nodes)
+    .enter()
+    .append('circle')
+    .attr('r', 5)
+    .attr('fill', '#60a5fa')
+    .call(
+      d3
+        .drag()
+        .on('start', (event, d) => {
+          if (!event.active) sim.alphaTarget(0.3).restart();
+          d.fx = d.x;
+          d.fy = d.y;
+        })
+        .on('drag', (event, d) => {
+          d.fx = event.x;
+          d.fy = event.y;
+        })
+        .on('end', (event, d) => {
+          if (!event.active) sim.alphaTarget(0);
+          d.fx = null;
+          d.fy = null;
+        })
+    );
+  const label = svg
+    .selectAll('text')
+    .data(nodes)
+    .enter()
+    .append('text')
+    .attr('font-size', '10px')
+    .attr('dx', 8)
+    .attr('dy', '.35em')
+    .text((d) => d.name);
+  sim.on('tick', () => {
+    link
+      .attr('x1', (d) => d.source.x)
+      .attr('y1', (d) => d.source.y)
+      .attr('x2', (d) => d.target.x)
+      .attr('y2', (d) => d.target.y);
+    node.attr('cx', (d) => d.x).attr('cy', (d) => d.y);
+    label.attr('x', (d) => d.x).attr('y', (d) => d.y);
+  });
 }
 
 function craftItem(prof, rid) {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,8 @@
 {
   "devDependencies": {
     "@eslint/js": "^9.32.0"
+  },
+  "scripts": {
+    "build-map": "node scripts/build-map.js"
   }
 }

--- a/scripts/build-map.js
+++ b/scripts/build-map.js
@@ -1,0 +1,50 @@
+const fs = require('fs');
+const path = require('path');
+
+const locations = JSON.parse(fs.readFileSync(path.join(__dirname, '../data/locations.json'), 'utf8'));
+
+const graph = {};
+const errors = [];
+
+for (const [id, loc] of Object.entries(locations)) {
+  graph[id] = {};
+  if (loc.links) {
+    for (const [dir, dest] of Object.entries(loc.links)) {
+      graph[id][dir] = dest;
+      if (!locations[dest]) {
+        errors.push(`Unknown destination ${dest} referenced in ${id}`);
+        continue;
+      }
+      const other = locations[dest];
+      const back = Object.values(other.links || {}).includes(id) || (other.boats || []).includes(id);
+      if (!back) {
+        errors.push(`Missing reverse link from ${dest} to ${id}`);
+      }
+    }
+  }
+  if (loc.boats) {
+    for (const dest of loc.boats) {
+      const key = `boat_${dest}`;
+      graph[id][key] = dest;
+      if (!locations[dest]) {
+        errors.push(`Unknown boat destination ${dest} referenced in ${id}`);
+        continue;
+      }
+      const other = locations[dest];
+      const back = (other.boats || []).includes(id) || Object.values(other.links || {}).includes(id);
+      if (!back) {
+        errors.push(`Missing reverse boat from ${dest} to ${id}`);
+      }
+    }
+  }
+}
+
+fs.writeFileSync(path.join(__dirname, '../data/map.json'), JSON.stringify(graph, null, 2));
+
+if (errors.length) {
+  console.error('Connection validation failed:');
+  for (const e of errors) console.error(' -', e);
+  process.exitCode = 1;
+} else {
+  console.log('All connections bidirectional.');
+}


### PR DESCRIPTION
## Summary
- generate a map graph from locations and verify exits are bidirectional
- expose `build-map` npm script for validation
- load D3 and new Graph panel in the UI
- render a force-directed graph of all zones

## Testing
- `node scripts/build-map.js`
- `npm run build-map`


------
https://chatgpt.com/codex/tasks/task_e_68880c700ce0832f85eef6036c2e3fc9