### PR TITLE
Generate placeholder zone files

### DIFF
--- a/data/zones/keldrith/emerald_copse.json
+++ b/data/zones/keldrith/emerald_copse.json
@@ -1,0 +1,27 @@
+{
+  "id": "emerald_copse",
+  "name": "Emerald Copse",
+  "description": "This is a placeholder description for Emerald Copse.",
+  "level_range": [
+    1,
+    5
+  ],
+  "type": "starter",
+  "exits": {
+    "north": "sylvaran_grove",
+    "east": "moonshade_thicket"
+  },
+  "mobs": [
+    {
+      "id": "placeholder_mob_01",
+      "name": "Placeholder Mob",
+      "level": 1,
+      "spawn_rate": 0.25
+    }
+  ],
+  "items": [],
+  "ambient_text": [
+    "The wind whistles through the trees.",
+    "You hear something rustling in the distance."
+  ]
+}

--- a/data/zones/keldrith/faeblight_vale.json
+++ b/data/zones/keldrith/faeblight_vale.json
@@ -1,0 +1,27 @@
+{
+  "id": "faeblight_vale",
+  "name": "Faeblight Vale",
+  "description": "This is a placeholder description for Faeblight Vale.",
+  "level_range": [
+    20,
+    30
+  ],
+  "type": "wildland",
+  "exits": {
+    "north": "rimebrook_falls",
+    "east": "wyrmroot_caverns"
+  },
+  "mobs": [
+    {
+      "id": "placeholder_mob_01",
+      "name": "Placeholder Mob",
+      "level": 20,
+      "spawn_rate": 0.25
+    }
+  ],
+  "items": [],
+  "ambient_text": [
+    "The wind whistles through the trees.",
+    "You hear something rustling in the distance."
+  ]
+}

--- a/data/zones/keldrith/ironfang_bluffs.json
+++ b/data/zones/keldrith/ironfang_bluffs.json
@@ -1,0 +1,26 @@
+{
+  "id": "ironfang_bluffs",
+  "name": "Ironfang Bluffs",
+  "description": "This is a placeholder description for Ironfang Bluffs.",
+  "level_range": [
+    40,
+    50
+  ],
+  "type": "wildland",
+  "exits": {
+    "west": "faeblight_vale"
+  },
+  "mobs": [
+    {
+      "id": "placeholder_mob_01",
+      "name": "Placeholder Mob",
+      "level": 40,
+      "spawn_rate": 0.25
+    }
+  ],
+  "items": [],
+  "ambient_text": [
+    "The wind whistles through the trees.",
+    "You hear something rustling in the distance."
+  ]
+}

--- a/data/zones/keldrith/moonshade_thicket.json
+++ b/data/zones/keldrith/moonshade_thicket.json
@@ -1,0 +1,27 @@
+{
+  "id": "moonshade_thicket",
+  "name": "Moonshade Thicket",
+  "description": "This is a placeholder description for Moonshade Thicket.",
+  "level_range": [
+    5,
+    10
+  ],
+  "type": "wildland",
+  "exits": {
+    "west": "emerald_copse",
+    "south": "webwood_hollow"
+  },
+  "mobs": [
+    {
+      "id": "placeholder_mob_01",
+      "name": "Placeholder Mob",
+      "level": 5,
+      "spawn_rate": 0.25
+    }
+  ],
+  "items": [],
+  "ambient_text": [
+    "The wind whistles through the trees.",
+    "You hear something rustling in the distance."
+  ]
+}

--- a/data/zones/keldrith/rimebrook_falls.json
+++ b/data/zones/keldrith/rimebrook_falls.json
@@ -1,0 +1,27 @@
+{
+  "id": "rimebrook_falls",
+  "name": "Rimebrook Falls",
+  "description": "This is a placeholder description for Rimebrook Falls.",
+  "level_range": [
+    15,
+    25
+  ],
+  "type": "wildland",
+  "exits": {
+    "south": "faeblight_vale",
+    "north": "webwood_hollow"
+  },
+  "mobs": [
+    {
+      "id": "placeholder_mob_01",
+      "name": "Placeholder Mob",
+      "level": 15,
+      "spawn_rate": 0.25
+    }
+  ],
+  "items": [],
+  "ambient_text": [
+    "The wind whistles through the trees.",
+    "You hear something rustling in the distance."
+  ]
+}

--- a/data/zones/keldrith/sylvaran_grove.json
+++ b/data/zones/keldrith/sylvaran_grove.json
@@ -1,0 +1,28 @@
+{
+  "id": "sylvaran_grove",
+  "name": "Sylvaran Grove",
+  "description": "This is a placeholder description for Sylvaran Grove.",
+  "level_range": [
+    0,
+    0
+  ],
+  "type": "city",
+  "exits": {
+    "south": "emerald_copse",
+    "portal": "tele_sandspire_sylvaran",
+    "ancient_tree": "tree_sylvaran_stormveil"
+  },
+  "mobs": [
+    {
+      "id": "placeholder_mob_01",
+      "name": "Placeholder Mob",
+      "level": 0,
+      "spawn_rate": 0.25
+    }
+  ],
+  "items": [],
+  "ambient_text": [
+    "The wind whistles through the trees.",
+    "You hear something rustling in the distance."
+  ]
+}

--- a/data/zones/keldrith/webwood_hollow.json
+++ b/data/zones/keldrith/webwood_hollow.json
@@ -1,0 +1,26 @@
+{
+  "id": "webwood_hollow",
+  "name": "Webwood Hollow",
+  "description": "This is a placeholder description for Webwood Hollow.",
+  "level_range": [
+    10,
+    20
+  ],
+  "type": "dungeon",
+  "exits": {
+    "north": "moonshade_thicket"
+  },
+  "mobs": [
+    {
+      "id": "placeholder_mob_01",
+      "name": "Placeholder Mob",
+      "level": 10,
+      "spawn_rate": 0.25
+    }
+  ],
+  "items": [],
+  "ambient_text": [
+    "The wind whistles through the trees.",
+    "You hear something rustling in the distance."
+  ]
+}

--- a/data/zones/keldrith/wyrmroot_caverns.json
+++ b/data/zones/keldrith/wyrmroot_caverns.json
@@ -1,0 +1,26 @@
+{
+  "id": "wyrmroot_caverns",
+  "name": "Wyrmroot Caverns",
+  "description": "This is a placeholder description for Wyrmroot Caverns.",
+  "level_range": [
+    30,
+    40
+  ],
+  "type": "dungeon",
+  "exits": {
+    "west": "faeblight_vale"
+  },
+  "mobs": [
+    {
+      "id": "placeholder_mob_01",
+      "name": "Placeholder Mob",
+      "level": 30,
+      "spawn_rate": 0.25
+    }
+  ],
+  "items": [],
+  "ambient_text": [
+    "The wind whistles through the trees.",
+    "You hear something rustling in the distance."
+  ]
+}

--- a/data/zones/veldara/ashmoor_fields.json
+++ b/data/zones/veldara/ashmoor_fields.json
@@ -1,0 +1,27 @@
+{
+  "id": "ashmoor_fields",
+  "name": "Ashmoor Fields",
+  "description": "This is a placeholder description for Ashmoor Fields.",
+  "level_range": [
+    1,
+    5
+  ],
+  "type": "starter",
+  "exits": {
+    "north": "ironvale_hold",
+    "east": "greystone_hills"
+  },
+  "mobs": [
+    {
+      "id": "placeholder_mob_01",
+      "name": "Placeholder Mob",
+      "level": 1,
+      "spawn_rate": 0.25
+    }
+  ],
+  "items": [],
+  "ambient_text": [
+    "The wind whistles through the trees.",
+    "You hear something rustling in the distance."
+  ]
+}

--- a/data/zones/veldara/briarcliff_woods.json
+++ b/data/zones/veldara/briarcliff_woods.json
@@ -1,0 +1,27 @@
+{
+  "id": "briarcliff_woods",
+  "name": "Briarcliff Woods",
+  "description": "This is a placeholder description for Briarcliff Woods.",
+  "level_range": [
+    15,
+    25
+  ],
+  "type": "wildland",
+  "exits": {
+    "west": "windfall_pass",
+    "south": "deepgrip_mines"
+  },
+  "mobs": [
+    {
+      "id": "placeholder_mob_01",
+      "name": "Placeholder Mob",
+      "level": 15,
+      "spawn_rate": 0.25
+    }
+  ],
+  "items": [],
+  "ambient_text": [
+    "The wind whistles through the trees.",
+    "You hear something rustling in the distance."
+  ]
+}

--- a/data/zones/veldara/deepgrip_mines.json
+++ b/data/zones/veldara/deepgrip_mines.json
@@ -1,0 +1,26 @@
+{
+  "id": "deepgrip_mines",
+  "name": "Deepgrip Mines",
+  "description": "This is a placeholder description for Deepgrip Mines.",
+  "level_range": [
+    20,
+    30
+  ],
+  "type": "dungeon",
+  "exits": {
+    "north": "briarcliff_woods"
+  },
+  "mobs": [
+    {
+      "id": "placeholder_mob_01",
+      "name": "Placeholder Mob",
+      "level": 20,
+      "spawn_rate": 0.25
+    }
+  ],
+  "items": [],
+  "ambient_text": [
+    "The wind whistles through the trees.",
+    "You hear something rustling in the distance."
+  ]
+}

--- a/data/zones/veldara/greystone_hills.json
+++ b/data/zones/veldara/greystone_hills.json
@@ -1,0 +1,28 @@
+{
+  "id": "greystone_hills",
+  "name": "Greystone Hills",
+  "description": "This is a placeholder description for Greystone Hills.",
+  "level_range": [
+    5,
+    10
+  ],
+  "type": "wildland",
+  "exits": {
+    "west": "ashmoor_fields",
+    "south": "howling_caverns",
+    "east": "windfall_pass"
+  },
+  "mobs": [
+    {
+      "id": "placeholder_mob_01",
+      "name": "Placeholder Mob",
+      "level": 5,
+      "spawn_rate": 0.25
+    }
+  ],
+  "items": [],
+  "ambient_text": [
+    "The wind whistles through the trees.",
+    "You hear something rustling in the distance."
+  ]
+}

--- a/data/zones/veldara/howling_caverns.json
+++ b/data/zones/veldara/howling_caverns.json
@@ -1,0 +1,26 @@
+{
+  "id": "howling_caverns",
+  "name": "Howling Caverns",
+  "description": "This is a placeholder description for Howling Caverns.",
+  "level_range": [
+    10,
+    15
+  ],
+  "type": "dungeon",
+  "exits": {
+    "north": "greystone_hills"
+  },
+  "mobs": [
+    {
+      "id": "placeholder_mob_01",
+      "name": "Placeholder Mob",
+      "level": 10,
+      "spawn_rate": 0.25
+    }
+  ],
+  "items": [],
+  "ambient_text": [
+    "The wind whistles through the trees.",
+    "You hear something rustling in the distance."
+  ]
+}

--- a/data/zones/veldara/ironvale_hold.json
+++ b/data/zones/veldara/ironvale_hold.json
@@ -1,0 +1,27 @@
+{
+  "id": "ironvale_hold",
+  "name": "Ironvale Hold",
+  "description": "This is a placeholder description for Ironvale Hold.",
+  "level_range": [
+    0,
+    0
+  ],
+  "type": "city",
+  "exits": {
+    "south": "ashmoor_fields",
+    "dock": "boat_ironvale_sandspire"
+  },
+  "mobs": [
+    {
+      "id": "placeholder_mob_01",
+      "name": "Placeholder Mob",
+      "level": 0,
+      "spawn_rate": 0.25
+    }
+  ],
+  "items": [],
+  "ambient_text": [
+    "The wind whistles through the trees.",
+    "You hear something rustling in the distance."
+  ]
+}

--- a/data/zones/veldara/stoneflame_mountains.json
+++ b/data/zones/veldara/stoneflame_mountains.json
@@ -1,0 +1,27 @@
+{
+  "id": "stoneflame_mountains",
+  "name": "Stoneflame Mountains",
+  "description": "This is a placeholder description for Stoneflame Mountains.",
+  "level_range": [
+    30,
+    40
+  ],
+  "type": "wildland",
+  "exits": {
+    "west": "briarcliff_woods",
+    "south": "verdan_outlands"
+  },
+  "mobs": [
+    {
+      "id": "placeholder_mob_01",
+      "name": "Placeholder Mob",
+      "level": 30,
+      "spawn_rate": 0.25
+    }
+  ],
+  "items": [],
+  "ambient_text": [
+    "The wind whistles through the trees.",
+    "You hear something rustling in the distance."
+  ]
+}

--- a/data/zones/veldara/verdan_outlands.json
+++ b/data/zones/veldara/verdan_outlands.json
@@ -1,0 +1,26 @@
+{
+  "id": "verdan_outlands",
+  "name": "Verdan Outlands",
+  "description": "This is a placeholder description for Verdan Outlands.",
+  "level_range": [
+    40,
+    50
+  ],
+  "type": "pvp",
+  "exits": {
+    "north": "stoneflame_mountains"
+  },
+  "mobs": [
+    {
+      "id": "placeholder_mob_01",
+      "name": "Placeholder Mob",
+      "level": 40,
+      "spawn_rate": 0.25
+    }
+  ],
+  "items": [],
+  "ambient_text": [
+    "The wind whistles through the trees.",
+    "You hear something rustling in the distance."
+  ]
+}

--- a/data/zones/veldara/windfall_pass.json
+++ b/data/zones/veldara/windfall_pass.json
@@ -1,0 +1,27 @@
+{
+  "id": "windfall_pass",
+  "name": "Windfall Pass",
+  "description": "This is a placeholder description for Windfall Pass.",
+  "level_range": [
+    10,
+    20
+  ],
+  "type": "wildland",
+  "exits": {
+    "west": "greystone_hills",
+    "east": "briarcliff_woods"
+  },
+  "mobs": [
+    {
+      "id": "placeholder_mob_01",
+      "name": "Placeholder Mob",
+      "level": 10,
+      "spawn_rate": 0.25
+    }
+  ],
+  "items": [],
+  "ambient_text": [
+    "The wind whistles through the trees.",
+    "You hear something rustling in the distance."
+  ]
+}

--- a/data/zones/vokarn/ashenflow_tundra.json
+++ b/data/zones/vokarn/ashenflow_tundra.json
@@ -1,0 +1,27 @@
+{
+  "id": "ashenflow_tundra",
+  "name": "Ashenflow Tundra",
+  "description": "This is a placeholder description for Ashenflow Tundra.",
+  "level_range": [
+    1,
+    10
+  ],
+  "type": "starter/hardmode",
+  "exits": {
+    "north": "stormveil_bastion",
+    "east": "frostbite_spires"
+  },
+  "mobs": [
+    {
+      "id": "placeholder_mob_01",
+      "name": "Placeholder Mob",
+      "level": 1,
+      "spawn_rate": 0.25
+    }
+  ],
+  "items": [],
+  "ambient_text": [
+    "The wind whistles through the trees.",
+    "You hear something rustling in the distance."
+  ]
+}

--- a/data/zones/vokarn/burnscar_chasm.json
+++ b/data/zones/vokarn/burnscar_chasm.json
@@ -1,0 +1,27 @@
+{
+  "id": "burnscar_chasm",
+  "name": "Burnscar Chasm",
+  "description": "This is a placeholder description for Burnscar Chasm.",
+  "level_range": [
+    40,
+    50
+  ],
+  "type": "wildland",
+  "exits": {
+    "north": "wailing_glacier",
+    "down": "dreadhold_depths"
+  },
+  "mobs": [
+    {
+      "id": "placeholder_mob_01",
+      "name": "Placeholder Mob",
+      "level": 40,
+      "spawn_rate": 0.25
+    }
+  ],
+  "items": [],
+  "ambient_text": [
+    "The wind whistles through the trees.",
+    "You hear something rustling in the distance."
+  ]
+}

--- a/data/zones/vokarn/dreadhold_depths.json
+++ b/data/zones/vokarn/dreadhold_depths.json
@@ -1,0 +1,27 @@
+{
+  "id": "dreadhold_depths",
+  "name": "Dreadhold Depths",
+  "description": "This is a placeholder description for Dreadhold Depths.",
+  "level_range": [
+    50,
+    60
+  ],
+  "type": "raid",
+  "exits": {
+    "up": "burnscar_chasm",
+    "portal": "raid_gate_every_capital"
+  },
+  "mobs": [
+    {
+      "id": "placeholder_mob_01",
+      "name": "Placeholder Mob",
+      "level": 50,
+      "spawn_rate": 0.25
+    }
+  ],
+  "items": [],
+  "ambient_text": [
+    "The wind whistles through the trees.",
+    "You hear something rustling in the distance."
+  ]
+}

--- a/data/zones/vokarn/frostbite_spires.json
+++ b/data/zones/vokarn/frostbite_spires.json
@@ -1,0 +1,27 @@
+{
+  "id": "frostbite_spires",
+  "name": "Frostbite Spires",
+  "description": "This is a placeholder description for Frostbite Spires.",
+  "level_range": [
+    20,
+    30
+  ],
+  "type": "dungeon",
+  "exits": {
+    "west": "ashenflow_tundra",
+    "south": "wailing_glacier"
+  },
+  "mobs": [
+    {
+      "id": "placeholder_mob_01",
+      "name": "Placeholder Mob",
+      "level": 20,
+      "spawn_rate": 0.25
+    }
+  ],
+  "items": [],
+  "ambient_text": [
+    "The wind whistles through the trees.",
+    "You hear something rustling in the distance."
+  ]
+}

--- a/data/zones/vokarn/stormveil_bastion.json
+++ b/data/zones/vokarn/stormveil_bastion.json
@@ -1,0 +1,27 @@
+{
+  "id": "stormveil_bastion",
+  "name": "Stormveil Bastion",
+  "description": "This is a placeholder description for Stormveil Bastion.",
+  "level_range": [
+    0,
+    0
+  ],
+  "type": "city",
+  "exits": {
+    "south": "ashenflow_tundra",
+    "tree_portal": "tree_sylvaran_stormveil"
+  },
+  "mobs": [
+    {
+      "id": "placeholder_mob_01",
+      "name": "Placeholder Mob",
+      "level": 0,
+      "spawn_rate": 0.25
+    }
+  ],
+  "items": [],
+  "ambient_text": [
+    "The wind whistles through the trees.",
+    "You hear something rustling in the distance."
+  ]
+}

--- a/data/zones/vokarn/wailing_glacier.json
+++ b/data/zones/vokarn/wailing_glacier.json
@@ -1,0 +1,27 @@
+{
+  "id": "wailing_glacier",
+  "name": "Wailing Glacier",
+  "description": "This is a placeholder description for Wailing Glacier.",
+  "level_range": [
+    30,
+    40
+  ],
+  "type": "wildland",
+  "exits": {
+    "north": "frostbite_spires",
+    "south": "burnscar_chasm"
+  },
+  "mobs": [
+    {
+      "id": "placeholder_mob_01",
+      "name": "Placeholder Mob",
+      "level": 30,
+      "spawn_rate": 0.25
+    }
+  ],
+  "items": [],
+  "ambient_text": [
+    "The wind whistles through the trees.",
+    "You hear something rustling in the distance."
+  ]
+}

--- a/data/zones/vokarn/worldrend_citadel.json
+++ b/data/zones/vokarn/worldrend_citadel.json
@@ -1,0 +1,26 @@
+{
+  "id": "worldrend_citadel",
+  "name": "Worldrend Citadel",
+  "description": "This is a placeholder description for Worldrend Citadel.",
+  "level_range": [
+    60,
+    65
+  ],
+  "type": "pvp/endgame",
+  "exits": {
+    "north": "burnscar_chasm"
+  },
+  "mobs": [
+    {
+      "id": "placeholder_mob_01",
+      "name": "Placeholder Mob",
+      "level": 60,
+      "spawn_rate": 0.25
+    }
+  ],
+  "items": [],
+  "ambient_text": [
+    "The wind whistles through the trees.",
+    "You hear something rustling in the distance."
+  ]
+}

--- a/data/zones/zhurakai/dusthold_ruins.json
+++ b/data/zones/zhurakai/dusthold_ruins.json
@@ -1,0 +1,26 @@
+{
+  "id": "dusthold_ruins",
+  "name": "Dusthold Ruins",
+  "description": "This is a placeholder description for Dusthold Ruins.",
+  "level_range": [
+    10,
+    20
+  ],
+  "type": "dungeon",
+  "exits": {
+    "north": "rattleshade_canyon"
+  },
+  "mobs": [
+    {
+      "id": "placeholder_mob_01",
+      "name": "Placeholder Mob",
+      "level": 10,
+      "spawn_rate": 0.25
+    }
+  ],
+  "items": [],
+  "ambient_text": [
+    "The wind whistles through the trees.",
+    "You hear something rustling in the distance."
+  ]
+}

--- a/data/zones/zhurakai/glasswaste_expanse.json
+++ b/data/zones/zhurakai/glasswaste_expanse.json
@@ -1,0 +1,27 @@
+{
+  "id": "glasswaste_expanse",
+  "name": "Glasswaste Expanse",
+  "description": "This is a placeholder description for Glasswaste Expanse.",
+  "level_range": [
+    25,
+    35
+  ],
+  "type": "wildland",
+  "exits": {
+    "north": "obelisk_ridge",
+    "east": "sunken_oasis"
+  },
+  "mobs": [
+    {
+      "id": "placeholder_mob_01",
+      "name": "Placeholder Mob",
+      "level": 25,
+      "spawn_rate": 0.25
+    }
+  ],
+  "items": [],
+  "ambient_text": [
+    "The wind whistles through the trees.",
+    "You hear something rustling in the distance."
+  ]
+}

--- a/data/zones/zhurakai/jadefire_tombs.json
+++ b/data/zones/zhurakai/jadefire_tombs.json
@@ -1,0 +1,26 @@
+{
+  "id": "jadefire_tombs",
+  "name": "Jadefire Tombs",
+  "description": "This is a placeholder description for Jadefire Tombs.",
+  "level_range": [
+    40,
+    50
+  ],
+  "type": "dungeon",
+  "exits": {
+    "north": "glasswaste_expanse"
+  },
+  "mobs": [
+    {
+      "id": "placeholder_mob_01",
+      "name": "Placeholder Mob",
+      "level": 40,
+      "spawn_rate": 0.25
+    }
+  ],
+  "items": [],
+  "ambient_text": [
+    "The wind whistles through the trees.",
+    "You hear something rustling in the distance."
+  ]
+}

--- a/data/zones/zhurakai/obelisk_ridge.json
+++ b/data/zones/zhurakai/obelisk_ridge.json
@@ -1,0 +1,27 @@
+{
+  "id": "obelisk_ridge",
+  "name": "Obelisk Ridge",
+  "description": "This is a placeholder description for Obelisk Ridge.",
+  "level_range": [
+    15,
+    25
+  ],
+  "type": "wildland",
+  "exits": {
+    "south": "glasswaste_expanse",
+    "north": "dusthold_ruins"
+  },
+  "mobs": [
+    {
+      "id": "placeholder_mob_01",
+      "name": "Placeholder Mob",
+      "level": 15,
+      "spawn_rate": 0.25
+    }
+  ],
+  "items": [],
+  "ambient_text": [
+    "The wind whistles through the trees.",
+    "You hear something rustling in the distance."
+  ]
+}

--- a/data/zones/zhurakai/rattleshade_canyon.json
+++ b/data/zones/zhurakai/rattleshade_canyon.json
@@ -1,0 +1,27 @@
+{
+  "id": "rattleshade_canyon",
+  "name": "Rattleshade Canyon",
+  "description": "This is a placeholder description for Rattleshade Canyon.",
+  "level_range": [
+    5,
+    10
+  ],
+  "type": "wildland",
+  "exits": {
+    "west": "scorched_flats",
+    "south": "dusthold_ruins"
+  },
+  "mobs": [
+    {
+      "id": "placeholder_mob_01",
+      "name": "Placeholder Mob",
+      "level": 5,
+      "spawn_rate": 0.25
+    }
+  ],
+  "items": [],
+  "ambient_text": [
+    "The wind whistles through the trees.",
+    "You hear something rustling in the distance."
+  ]
+}

--- a/data/zones/zhurakai/sandspire.json
+++ b/data/zones/zhurakai/sandspire.json
@@ -1,0 +1,28 @@
+{
+  "id": "sandspire",
+  "name": "Sandspire",
+  "description": "This is a placeholder description for Sandspire.",
+  "level_range": [
+    0,
+    0
+  ],
+  "type": "city",
+  "exits": {
+    "north": "scorched_flats",
+    "dock": "boat_ironvale_sandspire",
+    "teleport_pad": "tele_sandspire_sylvaran"
+  },
+  "mobs": [
+    {
+      "id": "placeholder_mob_01",
+      "name": "Placeholder Mob",
+      "level": 0,
+      "spawn_rate": 0.25
+    }
+  ],
+  "items": [],
+  "ambient_text": [
+    "The wind whistles through the trees.",
+    "You hear something rustling in the distance."
+  ]
+}

--- a/data/zones/zhurakai/scorched_flats.json
+++ b/data/zones/zhurakai/scorched_flats.json
@@ -1,0 +1,27 @@
+{
+  "id": "scorched_flats",
+  "name": "Scorched Flats",
+  "description": "This is a placeholder description for Scorched Flats.",
+  "level_range": [
+    1,
+    5
+  ],
+  "type": "starter",
+  "exits": {
+    "south": "sandspire",
+    "east": "rattleshade_canyon"
+  },
+  "mobs": [
+    {
+      "id": "placeholder_mob_01",
+      "name": "Placeholder Mob",
+      "level": 1,
+      "spawn_rate": 0.25
+    }
+  ],
+  "items": [],
+  "ambient_text": [
+    "The wind whistles through the trees.",
+    "You hear something rustling in the distance."
+  ]
+}

--- a/data/zones/zhurakai/sunken_oasis.json
+++ b/data/zones/zhurakai/sunken_oasis.json
@@ -1,0 +1,26 @@
+{
+  "id": "sunken_oasis",
+  "name": "Sunken Oasis",
+  "description": "This is a placeholder description for Sunken Oasis.",
+  "level_range": [
+    35,
+    45
+  ],
+  "type": "dungeon",
+  "exits": {
+    "west": "glasswaste_expanse"
+  },
+  "mobs": [
+    {
+      "id": "placeholder_mob_01",
+      "name": "Placeholder Mob",
+      "level": 35,
+      "spawn_rate": 0.25
+    }
+  ],
+  "items": [],
+  "ambient_text": [
+    "The wind whistles through the trees.",
+    "You hear something rustling in the distance."
+  ]
+}

--- a/generateZonePlaceholders.js
+++ b/generateZonePlaceholders.js
@@ -1,0 +1,37 @@
+const fs = require('fs');
+const path = require('path');
+
+const worldPath = path.join(__dirname, 'data', 'world.json');
+const world = JSON.parse(fs.readFileSync(worldPath, 'utf8'));
+
+world.continents.forEach((continent) => {
+  const continentDir = path.join(__dirname, 'data', 'zones', continent.id);
+  fs.mkdirSync(continentDir, { recursive: true });
+  continent.zones.forEach((zone) => {
+    const [minLevel, maxLevel] = zone.level_range;
+    const zonePath = path.join(continentDir, `${zone.id}.json`);
+    const placeholder = {
+      id: zone.id,
+      name: zone.name,
+      description: `This is a placeholder description for ${zone.name}.`,
+      level_range: [minLevel, maxLevel],
+      type: zone.type,
+      exits: zone.exits,
+      mobs: [
+        {
+          id: 'placeholder_mob_01',
+          name: 'Placeholder Mob',
+          level: minLevel,
+          spawn_rate: 0.25
+        }
+      ],
+      items: [],
+      ambient_text: [
+        'The wind whistles through the trees.',
+        'You hear something rustling in the distance.'
+      ]
+    };
+    fs.writeFileSync(zonePath, JSON.stringify(placeholder, null, 2));
+    console.log(`Created ${zonePath}`);
+  });
+});


### PR DESCRIPTION
## Summary
- create `generateZonePlaceholders.js` script that loads `world.json` and creates placeholder zone files
- generate placeholder data files for all zones in the world

## Testing
- `node generateZonePlaceholders.js`

------
https://chatgpt.com/codex/tasks/task_e_68880dce4c40832fadcd5d20b7d83fb7