### PR TITLE
Add worldState module and enhanced /who

### DIFF
--- a/main.js
+++ b/main.js
@@ -1,5 +1,6 @@
 import { loader } from './data/loader.js';
 import { ws } from './websocket-stub.js';
+import { worldState, classColors, formatPlaytime } from './worldState.js';
 
 const game = {
   player: null,
@@ -275,6 +276,13 @@ function addLog(txt) {
   div.scrollIntoView();
 }
 
+function addLogHTML(html) {
+  const div = document.createElement('div');
+  div.innerHTML = html;
+  document.getElementById('log').append(div);
+  div.scrollIntoView();
+}
+
 function addChat(txt) {
   const div = document.createElement('div');
   div.textContent = txt;
@@ -403,7 +411,7 @@ function updatePlayersList() {
   const list = document.getElementById('player-list');
   if (!list) return;
   list.innerHTML = '';
-  game.onlinePlayers.forEach((p) => {
+  worldState.getPlayerNames().forEach((p) => {
     const btn = document.createElement('button');
     btn.className = 'npc-btn text-xs';
     btn.textContent = p;
@@ -1141,7 +1149,23 @@ async function handleInput(text) {
   } else if (cmd === '/help') {
     showHelp();
   } else if (cmd === '/who') {
-    addLog(`Online: ${game.onlinePlayers.join(', ')}`);
+    const players = worldState.getPlayersSortedByLevel();
+    if (!players.length) {
+      addLog('No players online.');
+    } else {
+      let html = '<div><strong>Online Players:</strong></div>';
+      players.forEach((p) => {
+        const zone = worldState.getZone(p.name);
+        const gear = Object.values(p.equipped || {})
+          .map((id) => loader.get('items', id)?.name || id)
+          .join(', ') || 'None';
+        const color = classColors[p.class] || 'text-white';
+        const play = formatPlaytime(worldState.getPlaytimeMs(p.name));
+        const clsName = loader.data.classes[p.class]?.name || p.class;
+        html += `<div>${p.level} <span class="${color}">${clsName}</span> ${p.name} - ${zone} - GS ${p.gearScore} - ${play} - Gear: ${gear}</div>`;
+      });
+      addLogHTML(html);
+    }
   } else if (cmd.startsWith('/random')) {
     const [, type] = cmd.split(' ');
     if (type === 'item') {
@@ -1224,7 +1248,31 @@ async function startGame(player) {
   game.player = player;
   document.getElementById('create-overlay').classList.add('hidden');
   saveCharacter(player);
-  game.onlinePlayers = ['Hero', 'Adventurer', 'Mystic'];
+
+  worldState.addPlayer(player);
+  worldState.addPlayer({
+    name: 'Hero',
+    class: 'warrior',
+    level: 5,
+    location: 'greystone_hills',
+    equipped: { weapon: 'bronze_sword', chest: 'leather_armor' }
+  });
+  worldState.addPlayer({
+    name: 'Adventurer',
+    class: 'ranger',
+    level: 3,
+    location: 'gearhaven_plaza',
+    equipped: { weapon: 'hunter_bow', chest: 'leather_armor' }
+  });
+  worldState.addPlayer({
+    name: 'Mystic',
+    class: 'mage',
+    level: 8,
+    location: 'howling_caverns',
+    equipped: { weapon: 'druid_staff' }
+  });
+
+  game.onlinePlayers = worldState.getPlayerNames();
   updatePlayersList();
   bindUI();
   buildHotbar();

--- a/worldState.js
+++ b/worldState.js
@@ -1,0 +1,91 @@
+export const classColors = {
+  warrior: 'text-red-400',
+  paladin: 'text-amber-300',
+  cleric: 'text-emerald-300',
+  mage: 'text-blue-400',
+  rogue: 'text-yellow-300',
+  ranger: 'text-green-400',
+  druid: 'text-teal-300',
+  necromancer: 'text-purple-400',
+  shaman: 'text-orange-400',
+  bard: 'text-pink-400'
+};
+
+import { loader } from './data/loader.js';
+
+export function computeGearScore(equipped = {}) {
+  let score = 0;
+  Object.values(equipped).forEach((id) => {
+    const item = loader.get('items', id);
+    if (item && item.level) score += item.level;
+  });
+  return score;
+}
+
+export function zoneFromLocation(locId) {
+  if (!locId) return 'unknown';
+  const idx = locId.indexOf('_');
+  return idx === -1 ? locId : locId.slice(0, idx);
+}
+
+export function formatPlaytime(ms) {
+  const totalSec = Math.floor(ms / 1000);
+  const hrs = Math.floor(totalSec / 3600);
+  const mins = Math.floor((totalSec % 3600) / 60);
+  return `${hrs}h ${mins}m`;
+}
+
+export const worldState = {
+  players: {},
+
+  addPlayer(p) {
+    this.players[p.name] = {
+      name: p.name,
+      class: p.class,
+      level: p.level || 1,
+      location: p.location,
+      equipped: { ...(p.equipped || {}) },
+      loginTime: Date.now(),
+      pastPlaytime: p.playtimeMs || 0,
+      gearScore: computeGearScore(p.equipped)
+    };
+  },
+
+  removePlayer(name) {
+    delete this.players[name];
+  },
+
+  updatePlayer(name, data) {
+    const p = this.players[name];
+    if (!p) return;
+    Object.assign(p, data);
+    if (data.equipped) p.gearScore = computeGearScore(p.equipped);
+  },
+
+  getPlayer(name) {
+    return this.players[name];
+  },
+
+  getAllPlayers() {
+    return Object.values(this.players);
+  },
+
+  getPlayersSortedByLevel() {
+    return this.getAllPlayers().sort((a, b) => b.level - a.level);
+  },
+
+  getPlayerNames() {
+    return Object.keys(this.players);
+  },
+
+  getZone(name) {
+    const p = this.players[name];
+    return p ? zoneFromLocation(p.location) : 'unknown';
+  },
+
+  getPlaytimeMs(name) {
+    const p = this.players[name];
+    if (!p) return 0;
+    return Date.now() - p.loginTime + p.pastPlaytime;
+  }
+};


### PR DESCRIPTION
## Summary
- track online players in new `worldState.js`
- show players list based on `worldState`
- add `/who` command that lists players by level with colored class, gear, play time and gear score
- sample players added during startup
- support HTML logging for formatted output

## Testing
- `npm run build-map`

------
https://chatgpt.com/codex/tasks/task_e_68881125767c832fa1bceffe083ff694