### PR TITLE
Add player stats module and profile page

### DIFF
--- a/index.html
+++ b/index.html
@@ -17,6 +17,7 @@
       <button data-panel="map" class="btn">Map</button>
       <button data-panel="graph" class="btn">Graph</button>
       <button data-panel="craft" class="btn">Craft</button>
+      <a href="profile.html" class="btn">Profile</a>
     </nav>
   </header>
 

--- a/playerStats.js
+++ b/playerStats.js
@@ -1,0 +1,45 @@
+export const playerStats = {
+  data: {
+    STR: 10,
+    INT: 10,
+    DEX: 10,
+    CHA: 10,
+    END: 10,
+    WIS: 10,
+    LUK: 10
+  },
+  init() {
+    const saved = localStorage.getItem('playerStats');
+    if (saved) {
+      try {
+        const parsed = JSON.parse(saved);
+        Object.assign(this.data, parsed);
+      } catch {
+        // ignore corrupted data
+      }
+    }
+  },
+  save() {
+    localStorage.setItem('playerStats', JSON.stringify(this.data));
+  },
+  increase(stat, amount = 1) {
+    if (this.data[stat] == null) return;
+    this.data[stat] += amount;
+    this.save();
+  }
+};
+
+/**
+ * Apply stat bonuses from an item or quest reward.
+ * Expected format: { STR: 1, DEX: 2 }
+ * @param {Object<string, number>} bonus
+ */
+export function applyBonus(bonus) {
+  if (!bonus) return;
+  for (const [k, v] of Object.entries(bonus)) {
+    if (playerStats.data[k] != null) {
+      playerStats.data[k] += v;
+    }
+  }
+  playerStats.save();
+}

--- a/profile.html
+++ b/profile.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html lang="en" class="h-full">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width,initial-scale=1.0">
+  <title>Profile - Twilight Realms</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body class="h-full bg-slate-900 text-slate-200 flex flex-col">
+  <header class="shrink-0 p-2 bg-slate-800 flex items-center gap-4">
+    <h1 class="text-xl font-bold">Profile</h1>
+    <nav class="flex gap-2 text-sm">
+      <a href="index.html" class="btn">Back</a>
+    </nav>
+  </header>
+  <main class="grow p-4 space-y-2">
+    <div id="stats" class="space-y-1"></div>
+    <div class="text-slate-400 text-sm">Future growth paths will let you improve your attributes through quests, gear, or stat-tokens.</div>
+  </main>
+  <script type="module">
+    import { playerStats } from './playerStats.js';
+    playerStats.init();
+    const container = document.getElementById('stats');
+    for (const [key, value] of Object.entries(playerStats.data)) {
+      const div = document.createElement('div');
+      div.textContent = `${key}: ${value}`;
+      container.appendChild(div);
+    }
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- track base player stats in `playerStats.js`
- show stats on a new `profile.html` page
- link the profile page from the main navigation

## Testing
- `npx eslint playerStats.js`

------
https://chatgpt.com/codex/tasks/task_e_68881139cdac832f860e22560ea95335