### PR TITLE
Add phased quest system

### DIFF
--- a/data/loader.js
+++ b/data/loader.js
@@ -8,7 +8,6 @@ export const loader = {
       'classes',
       'deities',
       'items',
-      'quests',
       'locations',
       'crafting'
     ];
@@ -25,6 +24,16 @@ export const loader = {
       abilityFiles.map(async (f) => {
         const res = await fetch(`data/abilities/${f}.json`);
         Object.assign(this.data.abilities, await res.json());
+      })
+    );
+
+    const qIndexRes = await fetch('quests/index.json');
+    const questIds = await qIndexRes.json();
+    this.data.quests = {};
+    await Promise.all(
+      questIds.map(async (id) => {
+        const res = await fetch(`quests/${id}.json`);
+        this.data.quests[id] = await res.json();
       })
     );
   },

--- a/main.js
+++ b/main.js
@@ -222,6 +222,19 @@ function dropLoot(mob) {
   return loot;
 }
 
+function grantRewards(rewards) {
+  if (!rewards) return;
+  if (rewards.xp) {
+    game.player.xp += rewards.xp;
+    addLog(`You gain ${rewards.xp} XP.`);
+  }
+  (rewards.items || []).forEach((id) => {
+    game.player.inventory.push(id);
+    addLog(`You receive ${loader.data.items[id]?.name || id}.`);
+  });
+  updateHUD();
+}
+
 function updateHUD() {
   const p = game.player;
   const nameEl = document.getElementById('player-name');
@@ -540,7 +553,19 @@ function attackNpc(id) {
 function talkToNpc(id) {
   const npc = loader.get('npcs', id);
   if (!npc) return;
-  const line = npc.dialogue?.[0] || '...';
+  let line = npc.dialogue?.[0] || '...';
+  Object.entries(loader.data.quests).forEach(([qid, q]) => {
+    if (q.giver !== id) return;
+    if (game.player.activeQuests.includes(qid)) {
+      const stage = q.stages[game.player.questProgress[qid].stage];
+      if (stage.dialogue) line = stage.dialogue;
+    } else if (game.player.completedQuests.includes(qid)) {
+      const stage = q.stages[q.stages.length - 1];
+      if (stage.dialogue) line = stage.dialogue;
+    } else if (q.stages[0].dialogue) {
+      line = q.stages[0].dialogue;
+    }
+  });
   addLog(`${npc.name} says: "${line}"`);
   checkQuestProgress('talk', id);
   document.getElementById('dialogue').classList.add('hidden');
@@ -809,6 +834,7 @@ function completeQuest(qid) {
   game.player.activeQuests.splice(idx, 1);
   game.player.completedQuests.push(qid);
   delete game.player.questProgress[qid];
+  grantRewards(loader.data.quests[qid].rewards);
   addLog(`Quest completed: ${loader.data.quests[qid].name}`);
   buildQuestList();
 }
@@ -817,6 +843,8 @@ function advanceQuestStage(qid) {
   const q = loader.data.quests[qid];
   const prog = game.player.questProgress[qid];
   if (!q || !prog) return;
+  const stage = q.stages[prog.stage];
+  grantRewards(stage.rewards);
   if (prog.stage < q.stages.length - 1) {
     prog.stage += 1;
     prog.count = 0;
@@ -920,10 +948,15 @@ function showQuestDetails(qid) {
   const stage = q.stages[stageIdx];
   const objective = formatObjective(stage.objective);
   const rewards = [];
-  if (q.rewards?.xp) rewards.push(`${q.rewards.xp} XP`);
-  (q.rewards?.items || []).forEach((i) =>
-    rewards.push(loader.data.items[i]?.name || i)
-  );
+  const sr = stage.rewards || {};
+  if (sr.xp) rewards.push(`${sr.xp} XP`);
+  (sr.items || []).forEach((i) => rewards.push(loader.data.items[i]?.name || i));
+  if (stageIdx === q.stages.length - 1) {
+    if (q.rewards?.xp) rewards.push(`${q.rewards.xp} XP`);
+    (q.rewards?.items || []).forEach((i) =>
+      rewards.push(loader.data.items[i]?.name || i)
+    );
+  }
   const details = document.getElementById('quest-details');
   details.innerHTML = `
     <h3 class="text-md font-bold mb-1">${q.name}</h3>

--- a/quests/clear_the_bog.json
+++ b/quests/clear_the_bog.json
@@ -1,0 +1,20 @@
+{
+  "name": "Clear the Bog",
+  "giver": "bog_hunter",
+  "zones": ["shadowfen"],
+  "triggers": [],
+  "stages": [
+    {
+      "description": "Slay 2 bog creepers in Shadowfen.",
+      "objective": { "kill": "bog_creeper", "count": 2 },
+      "dialogue": "The mists hide many dangers. Bring me proof of two slain creepers.",
+      "rewards": { "xp": 60 }
+    },
+    {
+      "description": "Report back to the hunter.",
+      "objective": { "talk": "bog_hunter" },
+      "dialogue": "You've thinned their numbers? Good work, friend.",
+      "rewards": { "xp": 60, "items": ["mana_potion"] }
+    }
+  ]
+}

--- a/quests/fix_the_pipes.json
+++ b/quests/fix_the_pipes.json
@@ -1,0 +1,20 @@
+{
+  "name": "Fix the Pipes",
+  "giver": "thaldo_tinkerer",
+  "zones": ["gearhaven"],
+  "triggers": ["collect_parts"],
+  "stages": [
+    {
+      "description": "Collect 3 pipe parts from rogue clockworks.",
+      "objective": { "item": "pipe_part", "count": 3 },
+      "dialogue": "Those clockworks ran off with my pipe parts! Bring me three so I can make repairs.",
+      "rewards": { "xp": 50 }
+    },
+    {
+      "description": "Return to Thaldo.",
+      "objective": { "talk": "thaldo_tinkerer" },
+      "dialogue": "Excellent work! These parts will do nicely.",
+      "rewards": { "xp": 50, "items": ["healing_potion"] }
+    }
+  ]
+}

--- a/quests/gather_herbs.json
+++ b/quests/gather_herbs.json
@@ -1,0 +1,19 @@
+{
+  "name": "Gather Herbs",
+  "giver": "druid_npc",
+  "zones": ["gearhaven"],
+  "stages": [
+    {
+      "description": "Collect 5 healing herbs around Gearhaven.",
+      "objective": { "item": "healing_herb", "count": 5 },
+      "dialogue": "The forest provides all we need. Gather five herbs for me.",
+      "rewards": { "xp": 40 }
+    },
+    {
+      "description": "Bring the herbs to the druid.",
+      "objective": { "talk": "druid_npc" },
+      "dialogue": "Ah, such fresh herbs! Thank you.",
+      "rewards": { "xp": 40, "items": ["regrowth_scroll"] }
+    }
+  ]
+}

--- a/quests/index.json
+++ b/quests/index.json
@@ -1,0 +1,8 @@
+[
+  "fix_the_pipes",
+  "clear_the_bog",
+  "lost_lute",
+  "gather_herbs",
+  "scout_camp",
+  "welcome_to_realm"
+]

--- a/quests/lost_lute.json
+++ b/quests/lost_lute.json
@@ -1,0 +1,19 @@
+{
+  "name": "Lost Lute",
+  "giver": "bard_npc",
+  "zones": ["gearhaven"],
+  "stages": [
+    {
+      "description": "Retrieve the bard's lost lute from goblin raiders.",
+      "objective": { "item": "bard_lute", "count": 1 },
+      "dialogue": "My precious lute! Those goblins ran off with it.",
+      "rewards": { "xp": 75 }
+    },
+    {
+      "description": "Return the lute to the bard.",
+      "objective": { "talk": "bard_npc" },
+      "dialogue": "You've found it! I can perform once more.",
+      "rewards": { "xp": 75, "items": ["bard_lute"] }
+    }
+  ]
+}

--- a/quests/scout_camp.json
+++ b/quests/scout_camp.json
@@ -1,0 +1,19 @@
+{
+  "name": "Scout the Camp",
+  "giver": "ranger_npc",
+  "zones": ["goblin_forest"],
+  "stages": [
+    {
+      "description": "Investigate the goblin camp.",
+      "objective": { "location": "goblin_camp" },
+      "dialogue": "Sneak up and see what the goblins are plotting.",
+      "rewards": { "xp": 35 }
+    },
+    {
+      "description": "Report your findings to the ranger.",
+      "objective": { "talk": "ranger_npc" },
+      "dialogue": "Tell me everything you saw.",
+      "rewards": { "xp": 35 }
+    }
+  ]
+}

--- a/quests/welcome_to_realm.json
+++ b/quests/welcome_to_realm.json
@@ -1,0 +1,13 @@
+{
+  "name": "Welcome to Twilight Realms",
+  "giver": "thaldo_tinkerer",
+  "zones": ["gearhaven"],
+  "stages": [
+    {
+      "description": "Speak with Thaldo to learn the basics.",
+      "objective": { "talk": "thaldo_tinkerer" },
+      "dialogue": "Welcome, adventurer! Let's get you equipped.",
+      "rewards": { "xp": 50, "items": ["rusty_sword"] }
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- store individual quest definitions in `quests/{id}.json`
- load new quest files through `loader.js`
- add `grantRewards` helper and give rewards each stage
- show NPC dialogue based on quest phase

## Testing
- `npm run build-map`

------
https://chatgpt.com/codex/tasks/task_e_688811523a00832fa850733fd7f16591