### PR TITLE
Add codex lore journal

### DIFF
--- a/data/items.json
+++ b/data/items.json
@@ -61,7 +61,8 @@
     "level": 1,
     "damage": 2,
     "slot": "weapon",
-    "description": "Carved from an ancient tree."
+    "description": "Carved from an ancient tree.",
+    "relic": true
   },
   "shadow_dagger": {
     "name": "Shadow Dagger",

--- a/data/loader.js
+++ b/data/loader.js
@@ -27,6 +27,16 @@ export const loader = {
         Object.assign(this.data.abilities, await res.json());
       })
     );
+
+    const loreIdx = await fetch('data/lore/index.json');
+    const loreFiles = await loreIdx.json();
+    this.data.lore = {};
+    await Promise.all(
+      loreFiles.map(async (f) => {
+        const res = await fetch(`data/lore/${f}.json`);
+        this.data.lore[f] = await res.json();
+      })
+    );
   },
   get(type, id) {
     return this.data[type]?.[id];

--- a/data/lore/bosses.json
+++ b/data/lore/bosses.json
@@ -1,0 +1,6 @@
+{
+  "bog_creeper": {
+    "title": "The Bog Creeper",
+    "text": "Legends tell of a massive creeper that rules the wetlands with slimy terror." 
+  }
+}

--- a/data/lore/index.json
+++ b/data/lore/index.json
@@ -1,0 +1,1 @@
+["zones","bosses","relics"]

--- a/data/lore/relics.json
+++ b/data/lore/relics.json
@@ -1,0 +1,6 @@
+{
+  "druid_staff": {
+    "title": "Ancient Druid Staff",
+    "text": "This staff is said to be carved from the first tree that took root in Keldrith." 
+  }
+}

--- a/data/lore/zones.json
+++ b/data/lore/zones.json
@@ -1,0 +1,10 @@
+{
+  "gearhaven": {
+    "title": "Chronicles of Gearhaven",
+    "text": "Steam and gears power the city of Gearhaven where tinkerers craft wonders." 
+  },
+  "shadowfen": {
+    "title": "The Murk of Shadowfen",
+    "text": "Shadowfen's bogs swallow the light and nurture warriors loyal to Umbra." 
+  }
+}

--- a/data/mobs.json
+++ b/data/mobs.json
@@ -17,6 +17,7 @@
   "bog_creeper": {
     "name": "Bog Creeper",
     "level": 3,
+    "boss": true,
     "hp": 40,
     "damage": 5,
     "str": 7,

--- a/index.html
+++ b/index.html
@@ -17,6 +17,7 @@
       <button data-panel="map" class="btn">Map</button>
       <button data-panel="graph" class="btn">Graph</button>
       <button data-panel="craft" class="btn">Craft</button>
+      <button data-panel="codex" class="btn">Codex</button>
     </nav>
   </header>
 
@@ -89,10 +90,11 @@
     <div id="map" class="panel hidden bg-slate-800 p-4 rounded mb-4"></div>
     <div id="graph" class="panel hidden bg-slate-800 p-4 rounded mb-4"></div>
     <div id="craft" class="panel hidden bg-slate-800 p-4 rounded mb-4"></div>
+    <div id="codex" class="panel hidden bg-slate-800 p-4 rounded mb-4"></div>
     <div class="text-center">
       <button id="close-overlay" class="btn">Close</button>
     </div>
-</div>
+  </div>
   <!-- Hotbar for abilities -->
   <div id="hotbar" class="shrink-0 p-2 bg-slate-800 flex gap-1 overflow-x-auto"></div>
 

--- a/main.js
+++ b/main.js
@@ -22,6 +22,7 @@ function loadCharacter() {
   p.professions ||= [];
   p.coins ||= { copper: 0, silver: 0, gold: 0 };
   p.party ||= [];
+  p.codex ||= [];
   p.xp ||= 0;
   return p;
 }
@@ -323,6 +324,7 @@ function showPanel(name) {
   if (name === 'map') buildMap();
   if (name === 'graph') buildGraph();
   if (name === 'craft') buildCraftPanel();
+  if (name === 'codex') buildCodexPanel();
 }
 
 function renderRoom(loc) {
@@ -391,6 +393,7 @@ async function enterRoom(id) {
   checkQuestProgress('location', id);
   updateHUD();
   updateLocationPanel();
+  discoverZone(id);
 }
 
 async function move(dir) {
@@ -435,6 +438,7 @@ function endCombat(win) {
   document.getElementById('combat-overlay').classList.add('hidden');
   if (win) {
     addLog(`${mob.name} dies.`);
+    if (mob.boss) discoverBoss(mob.id);
     const loot = dropLoot(mob);
     game.player.coins.copper += loot.copper;
     game.player.coins.silver += loot.silver;
@@ -442,6 +446,7 @@ function endCombat(win) {
     loot.items.forEach((id) => {
       game.player.inventory.push(id);
       addLog(`You loot ${loader.data.items[id].name}.`);
+      if (loader.data.items[id]?.relic) discoverRelic(id);
       checkQuestProgress('item', id);
     });
     if (loot.copper || loot.silver || loot.gold) {
@@ -934,6 +939,60 @@ function showQuestDetails(qid) {
   `;
 }
 
+function getLoreTitle(key) {
+  const [type, id] = key.split('-', 2);
+  const map = { zone: 'zones', boss: 'bosses', relic: 'relics' };
+  return loader.data.lore?.[map[type]]?.[id]?.title || '';
+}
+
+function unlockLore(key) {
+  if (!game.player.codex.includes(key)) {
+    game.player.codex.push(key);
+    saveCharacter(game.player);
+    const title = getLoreTitle(key);
+    if (title) addLog(`Codex updated: ${title}`);
+  }
+}
+
+function discoverZone(locId) {
+  const zone = locId.split('_')[0];
+  if (loader.data.lore?.zones?.[zone]) unlockLore(`zone-${zone}`);
+}
+
+function discoverBoss(mobId) {
+  if (loader.data.lore?.bosses?.[mobId]) unlockLore(`boss-${mobId}`);
+}
+
+function discoverRelic(itemId) {
+  if (loader.data.lore?.relics?.[itemId]) unlockLore(`relic-${itemId}`);
+}
+
+function buildCodexPanel() {
+  const panel = document.getElementById('codex');
+  panel.innerHTML = '<h2 class="text-lg mb-2">Codex</h2>';
+  const book = document.createElement('div');
+  book.className = 'codex-book space-y-4 overflow-y-auto max-h-[70vh]';
+  if (!game.player.codex.length) {
+    book.textContent = 'You have not discovered any lore yet.';
+  } else {
+    game.player.codex.forEach((key) => {
+      const [type, id] = key.split('-', 2);
+      const map = { zone: 'zones', boss: 'bosses', relic: 'relics' };
+      const entry = loader.data.lore?.[map[type]]?.[id];
+      if (!entry) return;
+      const art = document.createElement('article');
+      const h3 = document.createElement('h3');
+      h3.className = 'font-bold text-lg mb-1';
+      h3.textContent = entry.title;
+      const p = document.createElement('p');
+      p.textContent = entry.text;
+      art.append(h3, p);
+      book.append(art);
+    });
+  }
+  panel.append(book);
+}
+
 function findPath(start, end) {
   const queue = [[start]];
   const visited = new Set([start]);
@@ -1072,6 +1131,7 @@ function craftItem(prof, rid) {
   }
   game.player.inventory.push(recipe.result);
   addLog(`You craft ${loader.data.items[recipe.result].name}.`);
+  if (loader.data.items[recipe.result]?.relic) discoverRelic(recipe.result);
   checkQuestProgress('item', recipe.result);
   buildInventory();
 }
@@ -1148,6 +1208,7 @@ async function handleInput(text) {
       const id = generateRandomItem(game.player.level);
       game.player.inventory.push(id);
       addLog(`You receive ${loader.data.items[id].name}.`);
+      if (loader.data.items[id]?.relic) discoverRelic(id);
     } else if (type === 'mob') {
       const mobId = generateRandomMob(game.player.level);
       startCombat(mobId);
@@ -1291,6 +1352,7 @@ function showCreateForm() {
       party: [],
       professions: [],
       coins: { copper: 0, silver: 0, gold: 0 },
+      codex: [],
       xp: 0
     };
     await startGame(player);

--- a/style.css
+++ b/style.css
@@ -42,3 +42,8 @@ body {
 .inventory-panel {
   @apply fixed right-0 top-0 bottom-0 w-64 p-4 bg-slate-800 overflow-y-auto hidden;
 }
+
+/* Codex book styling */
+.codex-book {
+  @apply bg-amber-100 text-slate-800 p-4 rounded shadow-inner font-serif;
+}


### PR DESCRIPTION
## Summary
- load lore files via new data/lore index
- track player codex entries and unlock on exploration, boss kill or relic obtain
- style codex panel like an in-game book
- add sample lore JSON files
- mark druid staff as a relic and bog creeper as a boss

## Testing
- `npm run build-map`
- `npx eslint .` *(fails: require is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_688811420ea0832f827eb0d055b9ab92