### PR TITLE
Add faction reputation system

### DIFF
--- a/data/mobs.json
+++ b/data/mobs.json
@@ -1,6 +1,7 @@
 {
   "rogue_clockwork": {
     "name": "Rogue Clockwork",
+    "faction": "luminara",
     "level": 2,
     "hp": 30,
     "damage": 4,
@@ -16,6 +17,7 @@
   },
   "bog_creeper": {
     "name": "Bog Creeper",
+    "faction": "umbra",
     "level": 3,
     "hp": 40,
     "damage": 5,
@@ -31,6 +33,7 @@
   },
   "goblin_raider": {
     "name": "Goblin Raider",
+    "faction": "umbra",
     "level": 2,
     "hp": 25,
     "damage": 3,

--- a/data/quests/clear_the_bog.json
+++ b/data/quests/clear_the_bog.json
@@ -2,6 +2,7 @@
   "name": "Clear the Bog",
   "giver": "bog_hunter",
   "zones": ["shadowfen"],
+  "faction": "umbra",
   "triggers": [],
   "stages": [
     {

--- a/data/quests/fix_the_pipes.json
+++ b/data/quests/fix_the_pipes.json
@@ -2,6 +2,7 @@
   "name": "Fix the Pipes",
   "giver": "thaldo_tinkerer",
   "zones": ["gearhaven"],
+  "faction": "luminara",
   "triggers": ["collect_parts"],
   "stages": [
     {

--- a/data/quests/gather_herbs.json
+++ b/data/quests/gather_herbs.json
@@ -2,6 +2,7 @@
   "name": "Gather Herbs",
   "giver": "druid_npc",
   "zones": ["gearhaven"],
+  "faction": "luminara",
   "stages": [
     {
       "description": "Collect 5 healing herbs around Gearhaven.",

--- a/data/quests/lost_lute.json
+++ b/data/quests/lost_lute.json
@@ -2,6 +2,7 @@
   "name": "Lost Lute",
   "giver": "bard_npc",
   "zones": ["gearhaven"],
+  "faction": "luminara",
   "stages": [
     {
       "description": "Retrieve the bard's lost lute from goblin raiders.",

--- a/data/quests/scout_camp.json
+++ b/data/quests/scout_camp.json
@@ -2,6 +2,7 @@
   "name": "Scout the Camp",
   "giver": "ranger_npc",
   "zones": ["goblin_forest"],
+  "faction": "neutral",
   "stages": [
     {
       "description": "Investigate the goblin camp.",

--- a/data/quests/welcome_to_realm.json
+++ b/data/quests/welcome_to_realm.json
@@ -2,6 +2,7 @@
   "name": "Welcome to Twilight Realms",
   "giver": "thaldo_tinkerer",
   "zones": ["gearhaven"],
+  "faction": "luminara",
   "stages": [
     {
       "description": "Speak with Thaldo to learn the basics.",

--- a/data/zones/dawn.json
+++ b/data/zones/dawn.json
@@ -1,4 +1,5 @@
 {
+  "faction": "luminara",
   "locations": {
     "dawn_isle_port": {
       "name": "Dawn Isle Port",

--- a/data/zones/dwarf.json
+++ b/data/zones/dwarf.json
@@ -1,4 +1,5 @@
 {
+  "faction": "luminara",
   "locations": {
     "dwarf_fort_path": {
       "name": "Stone Tunnel",

--- a/data/zones/elven.json
+++ b/data/zones/elven.json
@@ -1,4 +1,5 @@
 {
+  "faction": "luminara",
   "locations": {
     "elven_glade_path": {
       "name": "Elven Forest Road",

--- a/data/zones/gearhaven.json
+++ b/data/zones/gearhaven.json
@@ -1,4 +1,5 @@
 {
+  "faction": "luminara",
   "locations": {
     "gearhaven_plaza": {
       "name": "Cogwheel Plaza",

--- a/data/zones/gnome.json
+++ b/data/zones/gnome.json
@@ -1,4 +1,5 @@
 {
+  "faction": "luminara",
   "locations": {
     "gnome_burrow_path": {
       "name": "Gnome Tunnel",

--- a/data/zones/neutral.json
+++ b/data/zones/neutral.json
@@ -1,4 +1,5 @@
 {
+  "faction": "neutral",
   "locations": {
     "neutral_crossroads": {
       "name": "Crossroads",

--- a/data/zones/orc.json
+++ b/data/zones/orc.json
@@ -1,4 +1,5 @@
 {
+  "faction": "umbra",
   "locations": {
     "orc_stronghold_path": {
       "name": "Blasted Trail",

--- a/data/zones/shadowfen.json
+++ b/data/zones/shadowfen.json
@@ -1,4 +1,5 @@
 {
+  "faction": "umbra",
   "locations": {
     "shadowfen_camp": {
       "name": "Shadowfen Camp",

--- a/data/zones/undead.json
+++ b/data/zones/undead.json
@@ -1,4 +1,5 @@
 {
+  "faction": "umbra",
   "locations": {
     "undead_trail": {
       "name": "Forsaken Path",

--- a/main.js
+++ b/main.js
@@ -22,6 +22,7 @@ function loadCharacter() {
   p.professions ||= [];
   p.coins ||= { copper: 0, silver: 0, gold: 0 };
   p.party ||= [];
+  p.reputation ||= { luminara: 0, umbra: 0, neutral: 0 };
   p.xp ||= 0;
   return p;
 }
@@ -33,6 +34,18 @@ function isQuestGiver(id) {
 
 function rand(max) {
   return Math.floor(Math.random() * max) + 1;
+}
+
+function opposingFaction(fac) {
+  if (fac === 'luminara') return 'umbra';
+  if (fac === 'umbra') return 'luminara';
+  return null;
+}
+
+function adjustReputation(faction, amount) {
+  if (!faction || !game.player) return;
+  game.player.reputation[faction] =
+    (game.player.reputation[faction] || 0) + amount;
 }
 
 function getPlayerLevel() {
@@ -447,6 +460,11 @@ function endCombat(win) {
     if (loot.copper || loot.silver || loot.gold) {
       addLog(`You loot ${loot.gold}g ${loot.silver}s ${loot.copper}c.`);
     }
+    if (mob.faction) {
+      adjustReputation(mob.faction, -5);
+      const opp = opposingFaction(mob.faction);
+      if (opp) adjustReputation(opp, 5);
+    }
     showLoot(loot);
     checkQuestProgress('kill', mob.id);
   } else {
@@ -549,6 +567,12 @@ function talkToNpc(id) {
 function showNpcMenu(id) {
   const npc = loader.get('npcs', id);
   if (!npc) return;
+  const loc = loader.data.locations[game.player.location];
+  const fac = loc?.faction;
+  if (fac && game.player.reputation[fac] <= -10) {
+    addLog(`${npc.name} refuses to deal with you due to your reputation with ${fac}.`);
+    return;
+  }
   const dlg = document.getElementById('dialogue');
   dlg.innerHTML = `
     <div class="font-bold mb-1">${npc.name}</div>
@@ -750,6 +774,13 @@ function showHelp() {
   addLog(' /target <name> - target an NPC or object by name');
   addLog(' /help - show this help');
 }
+
+function showFactions() {
+  addLog('Faction Standings:');
+  Object.entries(game.player.reputation).forEach(([f, v]) => {
+    addLog(` ${f}: ${v}`);
+  });
+}
 function useItem(idx) {
   const id = game.player.inventory[idx];
   const item = loader.data.items[id];
@@ -809,6 +840,12 @@ function completeQuest(qid) {
   game.player.activeQuests.splice(idx, 1);
   game.player.completedQuests.push(qid);
   delete game.player.questProgress[qid];
+  const q = loader.data.quests[qid];
+  if (q?.faction) {
+    adjustReputation(q.faction, 10);
+    const opp = opposingFaction(q.faction);
+    if (opp) adjustReputation(opp, -5);
+  }
   addLog(`Quest completed: ${loader.data.quests[qid].name}`);
   buildQuestList();
 }
@@ -1142,6 +1179,8 @@ async function handleInput(text) {
     showHelp();
   } else if (cmd === '/who') {
     addLog(`Online: ${game.onlinePlayers.join(', ')}`);
+  } else if (cmd === '/factions') {
+    showFactions();
   } else if (cmd.startsWith('/random')) {
     const [, type] = cmd.split(' ');
     if (type === 'item') {
@@ -1291,6 +1330,7 @@ function showCreateForm() {
       party: [],
       professions: [],
       coins: { copper: 0, silver: 0, gold: 0 },
+      reputation: { luminara: 0, umbra: 0, neutral: 0 },
       xp: 0
     };
     await startGame(player);


### PR DESCRIPTION
## Summary
- add faction reputation tracking to player data
- track faction on mobs and quests
- annotate zones with a controlling faction
- modify combat and quests to adjust reputations
- block NPC interactions if reputation is too low
- add `/factions` command to view standings

## Testing
- `npm run build-map`


------
https://chatgpt.com/codex/tasks/task_e_688811ce00a4832f80c2f23fe6af4df6