### PR TITLE
Modern panel layout for REALM

### DIFF
--- a/data/quests.json
+++ b/data/quests.json
@@ -63,7 +63,7 @@
     }
   },
   "welcome_to_realm": {
-    "name": "Welcome to Twilight Realms",
+    "name": "Welcome to REALM",
     "giver": "thaldo_tinkerer",
     "description": "Speak with Thaldo to learn the basics.",
     "objective": {

--- a/data/quests/welcome_to_realm.json
+++ b/data/quests/welcome_to_realm.json
@@ -1,5 +1,5 @@
 {
-  "name": "Welcome to Twilight Realms",
+  "name": "Welcome to REALM",
   "giver": "thaldo_tinkerer",
   "zones": ["gearhaven"],
   "faction": "luminara",

--- a/index.html
+++ b/index.html
@@ -3,52 +3,44 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width,initial-scale=1.0">
-  <title>Twilight Realms</title>
+  <title>REALM</title>
   <!-- Tailwind via CDN -->
   <script src="https://cdn.tailwindcss.com"></script>
   <script src="https://unpkg.com/d3@7/dist/d3.min.js"></script>
   <link rel="stylesheet" href="style.css">
 </head>
-<body class="h-full bg-slate-900 text-slate-200 flex flex-col">
-  <!-- Header -->
-  <header class="shrink-0 p-2 bg-slate-800 flex items-center gap-4">
-    <h1 class="text-xl font-bold">Twilight Realms</h1>
+<body class="h-full bg-slate-900 text-slate-200 grid grid-rows-[auto_1fr_auto]">
+  <!-- Top HUD Bar -->
+  <header id="top-bar" class="p-2 bg-slate-800 flex flex-wrap justify-between items-center gap-4">
+    <div class="flex flex-wrap items-center gap-3">
+      <h1 class="text-xl font-bold">REALM</h1>
+      <span id="player-name" class="font-semibold"></span>
+      <span id="player-class"></span>
+      <span id="player-level"></span>
+      <div class="flex items-center gap-1">
+        <span class="text-xs">HP</span>
+        <div class="progress w-24"><div id="hp-fill" class="progress-fill"></div></div>
+        <span id="player-hp-text" class="w-14 text-right"></span>
+      </div>
+      <div class="flex items-center gap-1">
+        <span class="text-xs">XP</span>
+        <div class="progress w-24"><div id="xp-fill" class="progress-fill bg-blue-600"></div></div>
+        <span id="player-xp-text" class="w-14 text-right"></span>
+      </div>
+      <span id="player-gold"></span>
+    </div>
     <nav class="flex gap-2 text-sm">
+      <button data-tab="tab-inventory" class="btn tab-btn">Inventory</button>
+      <button data-tab="tab-quests" class="btn tab-btn">Quests</button>
       <button data-panel="map" class="btn">Map</button>
-      <button data-panel="graph" class="btn">Graph</button>
-      <button data-panel="craft" class="btn">Craft</button>
-      <a href="profile.html" class="btn">Profile</a>
-      <button data-panel="codex" class="btn">Codex</button>
+      <a href="profile.html" class="btn">Settings</a>
     </nav>
   </header>
 
-  <!-- Player info bar -->
-  <div id="player-bar" class="shrink-0 p-2 bg-slate-700 flex justify-between text-sm">
-    <span id="player-name">Name: —</span>
-    <span id="player-hp">HP: --/--</span>
-    <span id="player-xp">XP: 0</span>
-  </div>
-
   <!-- Main layout -->
 
-  <main class="grow grid md:grid-cols-[16rem_1fr_16rem_16rem] gap-2 p-2 overflow-hidden">
+  <main class="grow grid md:grid-cols-[16rem_1fr_16rem] gap-2 p-2 overflow-hidden">
     <aside id="left-panel" class="bg-slate-800 p-3 rounded flex flex-col gap-2 overflow-y-auto">
-      <div id="inv" class="hud-box"></div>
-    </aside>
-
-    <div class="flex flex-col gap-2 overflow-hidden">
-      <section id="log" class="grow bg-slate-800 p-3 rounded overflow-y-auto"></section>
-      <footer class="shrink-0 p-2 bg-slate-800 flex gap-2">
-        <input id="cmd" class="flex-grow bg-slate-700 p-2 rounded" placeholder="Type command or /help">
-        <button id="send" class="btn">Send</button>
-      </footer>
-    </div>
-
-    <aside id="right-panel" class="bg-slate-800 p-3 rounded flex flex-col gap-2 overflow-y-auto">
-      <div id="status" class="hud-box">HP: --/-- MP: --/--</div>
-      <div id="target" class="hud-box">Target: —</div>
-      <div id="party" class="hud-box">Party: —</div>
-      <div id="currency" class="hud-box">Coins: 0g 0s 0c</div>
       <div id="zone-panel" class="hud-box">
         <div id="zone-name" class="font-bold mb-1">Zone</div>
         <div id="zone-desc" class="text-xs mb-1"></div>
@@ -78,12 +70,40 @@
         <div class="font-bold mb-1">Actions</div>
         <div id="actions-panel" class="flex flex-wrap gap-1"></div>
       </div>
-      <div id="dialogue" class="hud-box hidden"></div>
-      <div id="chat-panel" class="hud-box flex-grow overflow-y-auto"></div>
       <div id="minimap" class="hud-box h-40"></div>
     </aside>
-    <aside id="quest-sidebar" class="bg-slate-800 p-3 rounded flex flex-col gap-2 overflow-y-auto">
-      <div id="quests" class="hud-box flex-grow overflow-y-auto"></div>
+
+    <div class="flex flex-col gap-2 overflow-hidden">
+      <section id="log" class="grow bg-slate-800 p-3 rounded overflow-y-auto"></section>
+      <footer class="shrink-0 p-2 bg-slate-800 flex gap-2">
+        <input id="cmd" class="flex-grow bg-slate-700 p-2 rounded" placeholder="Type command or /help">
+        <button id="send" class="btn">Send</button>
+      </footer>
+    </div>
+
+    <aside id="right-panel" class="bg-slate-800 p-3 rounded flex flex-col gap-2 overflow-y-auto">
+      <div id="status" class="hud-box">HP: --/-- MP: --/--</div>
+      <div id="target" class="hud-box">Target: —</div>
+      <div id="party" class="hud-box">Party: —</div>
+      <div id="currency" class="hud-box">Coins: 0g 0s 0c</div>
+      <div class="tabs flex gap-1 mb-2">
+        <button data-tab="tab-inventory" class="btn tab-btn text-xs">Inventory</button>
+        <button data-tab="tab-quests" class="btn tab-btn text-xs">Quests</button>
+        <button data-tab="tab-mob" class="btn tab-btn text-xs">Mob Info</button>
+        <button data-tab="tab-lore" class="btn tab-btn text-xs">Lore</button>
+      </div>
+      <div class="tab-content flex-grow overflow-y-auto">
+        <div id="tab-inventory" class="tab-panel">
+          <div id="inv" class="hud-box"></div>
+        </div>
+        <div id="tab-quests" class="tab-panel hidden">
+          <div id="quests" class="hud-box"></div>
+        </div>
+        <div id="tab-mob" class="tab-panel hidden">
+          <div id="dialogue" class="hud-box hidden"></div>
+        </div>
+        <div id="tab-lore" class="tab-panel hidden"></div>
+      </div>
     </aside>
   </main>
   <!-- Overlay panels -->
@@ -106,6 +126,9 @@
   </div>
   <!-- Hotbar for abilities -->
   <div id="hotbar" class="shrink-0 p-2 bg-slate-800 flex gap-1 overflow-x-auto"></div>
+
+  <!-- Chat dock -->
+  <div id="chat-panel" class="shrink-0 bg-slate-800 p-2 h-32 overflow-y-auto"></div>
 
   <!-- Movement controls -->
   <div id="move-controls" class="shrink-0 p-2 bg-slate-800 flex gap-1 justify-center"></div>

--- a/lore.js
+++ b/lore.js
@@ -1,4 +1,4 @@
-// Lore generation module for Twilight realm
+// Lore generation module for REALM
 
 /**
  * Pick a random element from an array.
@@ -37,7 +37,7 @@ function hauntedLine(region) {
     'silently stalks the unwary'
   ];
   const endings = [
-    'in service to the Twilight realm.',
+    'in service to the Realm.',
     'seeking vengeance from ages past.',
     'bound to secrets best left untouched.',
     'watching over ruins swallowed by gloom.',
@@ -74,7 +74,7 @@ function desertLine(region) {
     'guard secrets in scorched stone'
   ];
   const endings = [
-    'bound forever to the Twilight realm.',
+    'bound forever to the Realm.',
     'holding relics no mortal remembers.',
     'speaking in silence to those who listen.',
     'offering riches and curses alike.',
@@ -111,7 +111,7 @@ function tundraLine(region) {
     'sing mournful dirges'
   ];
   const endings = [
-    'remembering the Twilight realm.',
+    'remembering the Realm.',
     'waiting for the thaw that never comes.',
     'echoing through endless winter.',
     'guarding pathways to other worlds.',
@@ -148,7 +148,7 @@ function volcanicLine(region) {
     'illuminate secrets below'
   ];
   const endings = [
-    'at the heart of the Twilight realm.',
+    'at the heart of the Realm.',
     'as warnings to heedless travelers.',
     'revealing passages of power.',
     'in honor of forgotten fire gods.',

--- a/main.js
+++ b/main.js
@@ -295,10 +295,21 @@ function updateHUD() {
     const title = p.achievements.title ? ` ${p.achievements.title}` : '';
     nameEl.textContent = p.name + title;
   }
-  const hpEl = document.getElementById('player-hp');
-  if (hpEl) hpEl.textContent = `HP: ${p.hp}/${p.maxHp}`;
-  const xpEl = document.getElementById('player-xp');
-  if (xpEl) xpEl.textContent = `XP: ${p.xp || 0}`;
+  const clsEl = document.getElementById('player-class');
+  if (clsEl) clsEl.textContent = p.class;
+  const lvlEl = document.getElementById('player-level');
+  if (lvlEl) lvlEl.textContent = `Lv ${getPlayerLevel()}`;
+  const hpText = document.getElementById('player-hp-text');
+  if (hpText) hpText.textContent = `${p.hp}/${p.maxHp}`;
+  const hpFill = document.getElementById('hp-fill');
+  if (hpFill) hpFill.style.width = `${(p.hp / p.maxHp) * 100}%`;
+  const xpText = document.getElementById('player-xp-text');
+  if (xpText) xpText.textContent = p.xp || 0;
+  const xpFill = document.getElementById('xp-fill');
+  if (xpFill) xpFill.style.width = `${(p.xp % 100)}%`;
+  const goldEl = document.getElementById('player-gold');
+  if (goldEl)
+    goldEl.textContent = `${p.coins.gold}g ${p.coins.silver}s ${p.coins.copper}c`;
 }
 
 function updateLocationPanel() {
@@ -1605,6 +1616,16 @@ function bindUI() {
   document.querySelectorAll('button[data-panel]').forEach((btn) => {
     btn.onclick = () => showPanel(btn.dataset.panel);
   });
+  document.querySelectorAll('.tab-btn').forEach((btn) => {
+    btn.onclick = () => {
+      document.querySelectorAll('.tab-btn').forEach((b) => b.classList.remove('active'));
+      document.querySelectorAll('.tab-panel').forEach((p) => p.classList.add('hidden'));
+      btn.classList.add('active');
+      document.getElementById(btn.dataset.tab).classList.remove('hidden');
+    };
+  });
+  const firstTab = document.querySelector('.tab-btn');
+  if (firstTab) firstTab.click();
   document.getElementById('close-overlay').onclick = () => {
     document.getElementById('overlay').classList.add('hidden');
   };

--- a/profile.html
+++ b/profile.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width,initial-scale=1.0">
-  <title>Profile - Twilight Realms</title>
+  <title>Profile - REALM</title>
   <script src="https://cdn.tailwindcss.com"></script>
   <link rel="stylesheet" href="style.css">
 </head>

--- a/quests/welcome_to_realm.json
+++ b/quests/welcome_to_realm.json
@@ -1,5 +1,5 @@
 {
-  "name": "Welcome to Twilight Realms",
+  "name": "Welcome to REALM",
   "giver": "thaldo_tinkerer",
   "zones": ["gearhaven"],
   "stages": [

--- a/style.css
+++ b/style.css
@@ -47,3 +47,19 @@ body {
 .codex-book {
   @apply bg-amber-100 text-slate-800 p-4 rounded shadow-inner font-serif;
 }
+
+/* Progress bars */
+.progress {
+  @apply w-full h-2 bg-slate-700 rounded overflow-hidden;
+}
+.progress-fill {
+  @apply h-full bg-green-600;
+}
+
+/* Tabs */
+.tab-btn.active {
+  @apply bg-indigo-500;
+}
+.tab-panel {
+  @apply w-full;
+}


### PR DESCRIPTION
## Summary
- rebrand Twilight Realms to **REALM** across UI and quest data
- redesign index layout into a four‑panel grid with bottom chat dock
- add progress bar components and tabbed sidebar
- update HUD logic and UI bindings for the new layout

## Testing
- `npm install`
- `node -c main.js`
- `node -c lore.js`


------
https://chatgpt.com/codex/tasks/task_e_6888457b36d0832fb87c40a97af3c499