### PR TITLE
Fix loader fetch paths for GitHub Pages

### DIFF
--- a/data/loader.js
+++ b/data/loader.js
@@ -2,8 +2,9 @@ let nodeFS;
 let nodePath;
 let fileURLToPathFn;
 let rootDir;
+let browserRoot;
 
-async function fetchJson(rel) {
+export async function fetchJson(rel) {
   if (typeof window === 'undefined') {
     if (!nodeFS) {
       nodeFS = (await import('fs/promises')).default;
@@ -17,7 +18,10 @@ async function fetchJson(rel) {
     const full = nodePath.join(rootDir, rel);
     return JSON.parse(await nodeFS.readFile(full, 'utf8'));
   }
-  const res = await fetch(rel);
+  if (!browserRoot) {
+    browserRoot = new URL('..', import.meta.url);
+  }
+  const res = await fetch(new URL(rel, browserRoot));
   if (!res.ok) {
     throw new Error(`Failed to fetch ${rel}: ${res.status}`);
   }
@@ -76,13 +80,11 @@ export const loader = {
     if (savedGuilds) {
       this.data.guilds = JSON.parse(savedGuilds);
     }
-    const loreIdx = await fetch('data/lore/index.json');
-    const loreFiles = await loreIdx.json();
+    const loreFiles = await fetchJson('data/lore/index.json');
     this.data.lore = {};
     await Promise.all(
       loreFiles.map(async (f) => {
-        const res = await fetch(`data/lore/${f}.json`);
-        this.data.lore[f] = await res.json();
+        this.data.lore[f] = await fetchJson(`data/lore/${f}.json`);
       })
     );
   },

--- a/events.js
+++ b/events.js
@@ -1,4 +1,4 @@
-import { loader } from './data/loader.js';
+import { loader, fetchJson } from './data/loader.js';
 import { ws } from './websocket-stub.js';
 
 const active = [];
@@ -73,8 +73,7 @@ function checkEvents() {
 
 export async function initEvents() {
   try {
-    const res = await fetch('data/events.json');
-    loader.data.events = await res.json();
+    loader.data.events = await fetchJson('data/events.json');
   } catch {
     loader.data.events = [];
   }

--- a/main.js
+++ b/main.js
@@ -1,4 +1,4 @@
-import { loader } from './data/loader.js';
+import { loader, fetchJson } from './data/loader.js';
 import { ws } from './websocket-stub.js';
 import { initEvents } from './events.js';
 import { worldState } from './worldState.js';
@@ -546,8 +546,7 @@ async function loadZoneMobs(zoneId) {
   if (game.currentZone.id === zoneId) return;
   game.currentZone = { id: zoneId, mobs: [] };
   try {
-    const res = await fetch(`data/mobs/${zoneId}.json`);
-    const data = await res.json();
+    const data = await fetchJson(`data/mobs/${zoneId}.json`);
     if (Array.isArray(data.mobs)) {
       game.currentZone.mobs = data.mobs;
     } else {
@@ -1309,8 +1308,7 @@ function buildMap() {
 async function buildGraph() {
   const panel = document.getElementById('graph');
   panel.innerHTML = '<h2 class="text-lg mb-2">World Graph</h2><svg width="600" height="600"></svg>';
-  const res = await fetch('data/map.json');
-  const graph = await res.json();
+  const graph = await fetchJson('data/map.json');
   const nodes = Object.keys(graph).map((id) => ({ id, name: loader.data.locations[id]?.name || id }));
   const links = [];
   Object.entries(graph).forEach(([src, exits]) => {


### PR DESCRIPTION
## Summary
- make loader `fetchJson` compute absolute paths based on script URL
- export `fetchJson` for other modules
- update `events.js` and `main.js` to use new helper

## Testing
- `npm run build-map`
- `npm run clear-events`


------
https://chatgpt.com/codex/tasks/task_e_68884b455d3c832f986b3c5014c91c75