### PR TITLE
Fix zone detection

### DIFF
--- a/main.js
+++ b/main.js
@@ -540,7 +540,7 @@ function gearScore(player) {
 }
 
 function zoneOf(loc) {
-  return loc || '';
+  return zoneFromLocation(loc);
 }
 
 function getZoneData(id) {

--- a/worldState.js
+++ b/worldState.js
@@ -24,8 +24,16 @@ export function computeGearScore(equipped = {}) {
 
 export function zoneFromLocation(locId) {
   if (!locId) return 'unknown';
-  const idx = locId.indexOf('_');
-  return idx === -1 ? locId : locId.slice(0, idx);
+  const world = loader.data.world;
+  const parts = locId.split('_');
+  while (parts.length > 1) {
+    const candidate = parts.join('_');
+    if (world?.continents?.some((c) => c.zones.some((z) => z.id === candidate))) {
+      return candidate;
+    }
+    parts.pop();
+  }
+  return parts.join('_');
 }
 
 export function formatPlaytime(ms) {


### PR DESCRIPTION
## Summary
- correct zone detection logic in worldState.js
- use new zoneFromLocation in zoneOf

## Testing
- `node - <<'EOF'
import { loader } from './data/loader.js';
import { zoneFromLocation } from './worldState.js';
const test = async () => {
  await loader.init();
  console.log(zoneFromLocation('ashmoor_fields'));
  console.log(zoneFromLocation('shadowfen_camp'));
  console.log(zoneFromLocation('ashmoor_fields_farm'));
};
await test();
EOF`

------
https://chatgpt.com/codex/tasks/task_e_6889111f6f38832f9720620df75a432b