### PR TITLE
Fix missing location entries

### DIFF
--- a/data/loader.js
+++ b/data/loader.js
@@ -90,6 +90,25 @@ export const loader = {
         this.data.lore[f] = await fetchJson(`data/lore/${f}.json`);
       })
     );
+
+    if (this.data.world?.continents) {
+      this.data.locations ||= {};
+      for (const cont of this.data.world.continents) {
+        for (const zone of cont.zones) {
+          if (!this.data.locations[zone.id]) {
+            this.data.locations[zone.id] = {
+              name: zone.name,
+              description: zone.description || `The ${zone.name}.`,
+              exits: Object.keys(zone.exits || {}),
+              links: zone.exits || {},
+              npcs: [],
+              spawns: [],
+              nodes: []
+            };
+          }
+        }
+      }
+    }
   },
   get(type, id) {
     return this.data[type]?.[id];


### PR DESCRIPTION
## Summary
- generate placeholder locations for every zone when loading data

## Testing
- `npx eslint data/loader.js`
- `node -e "import('./data/loader.js').then(m=>m.loader.init().then(()=>console.log('loaded',!!m.loader.data.locations['scorched_flats'])))"`

------
https://chatgpt.com/codex/tasks/task_e_688961f29ec4832fb3969280f4fbde93