### PR TITLE
Add shared dynamic mobs

### DIFF
--- a/main.js
+++ b/main.js
@@ -475,7 +475,7 @@ async function enterRoom(id) {
   await loadZoneMobs(zoneOf(id));
   const ids = [...(loc.npcs || []), ...(loc.spawns || [])];
   await Promise.all(ids.map((nid) => loader.loadNpc(nid)));
-  spawnMobsForLocation(loc);
+  spawnMobsForLocation(loc, id);
   game.player.location = id;
   location.hash = id;
   renderRoom(loc);
@@ -578,6 +578,7 @@ async function loadZoneMobs(zoneId) {
     const data = await fetchJson(`data/mobs/${zoneId}.json`);
     if (Array.isArray(data.mobs)) {
       game.currentZone.mobs = data.mobs;
+      worldState.initZone(zoneId, game.currentZone.mobs);
     } else {
       console.warn('Invalid mob data for zone', zoneId);
     }
@@ -599,16 +600,11 @@ function createZoneMob(tpl) {
   return id;
 }
 
-function spawnMobsForLocation(loc) {
+function spawnMobsForLocation(loc, locId) {
   if (!loc._baseSpawns) loc._baseSpawns = [...(loc.spawns || [])];
   loc.spawns = loc._baseSpawns.slice();
-  if (!game.currentZone.mobs.length) return;
-  game.currentZone.mobs.forEach((tpl) => {
-    if (Math.random() < tpl.spawn_rate) {
-      const id = createZoneMob(tpl);
-      loc.spawns.push(id);
-    }
-  });
+  const zid = zoneFromLocation(locId || game.player.location);
+  loc.spawns = loc.spawns.concat(worldState.getMobIds(zid));
 }
 
 function getRandomMobForZone() {
@@ -678,6 +674,9 @@ function endCombat(win) {
   document.getElementById('combat-overlay').classList.add('hidden');
   if (win) {
     addLog(`${mob.name} dies.`);
+    if (mob.id.startsWith('zone_')) {
+      worldState.killMob(zoneOf(game.player.location), mob.id);
+    }
     if (mob.boss) discoverBoss(mob.id);
     const loot = dropLoot(mob);
     game.player.coins.copper += loot.copper;
@@ -1643,6 +1642,22 @@ function bindUI() {
   ws.on('chat', (m) => {
     addLog(`[${m.channel}] ${m.msg}`);
     addChat(`[${m.channel}] ${m.msg}`);
+  });
+  ws.on('mob_spawn', ({ zoneId, mobId, mob }) => {
+    loader.data.mobs[mobId] = mob;
+    const loc = loader.data.locations[zoneId];
+    if (loc && !loc.spawns.includes(mobId)) {
+      loc.spawns.push(mobId);
+      if (game.player.location === zoneId) buildMobList(loc.spawns);
+    }
+  });
+  ws.on('mob_remove', ({ zoneId, mobId }) => {
+    const loc = loader.data.locations[zoneId];
+    if (loc) {
+      loc.spawns = loc.spawns.filter((id) => id !== mobId);
+      delete loader.data.mobs[mobId];
+      if (game.player.location === zoneId) buildMobList(loc.spawns);
+    }
   });
   document.querySelectorAll('button[data-panel]').forEach((btn) => {
     btn.onclick = () => showPanel(btn.dataset.panel);

--- a/worldState.js
+++ b/worldState.js
@@ -12,6 +12,7 @@ export const classColors = {
 };
 
 import { loader } from './data/loader.js';
+import { ws } from './websocket-stub.js';
 
 export function computeGearScore(equipped = {}) {
   let score = 0;
@@ -45,6 +46,7 @@ export function formatPlaytime(ms) {
 
 export const worldState = {
   players: {},
+  zones: {},
 
   addPlayer(p) {
     this.players[p.name] = {
@@ -95,5 +97,64 @@ export const worldState = {
     const p = this.players[name];
     if (!p) return 0;
     return Date.now() - p.loginTime + p.pastPlaytime;
+  },
+
+  initZone(zoneId, templates) {
+    if (this.zones[zoneId]) return;
+    this.zones[zoneId] = { templates, mobs: {} };
+    for (let i = 0; i < 10; i++) {
+      const tpl = this._randomTemplate(zoneId);
+      if (tpl) this.spawnMob(zoneId, tpl);
+    }
+  },
+
+  _randomTemplate(zoneId) {
+    const zone = this.zones[zoneId];
+    if (!zone) return null;
+    const total = zone.templates.reduce((s, t) => s + t.spawn_rate, 0);
+    let roll = Math.random() * total;
+    for (const tpl of zone.templates) {
+      roll -= tpl.spawn_rate;
+      if (roll <= 0) return tpl;
+    }
+    return zone.templates[0];
+  },
+
+  spawnMob(zoneId, tpl) {
+    const level = this._randRange(tpl.level_range[0], tpl.level_range[1]);
+    const id = `zone_${zoneId}_${tpl.id}_${Date.now()}_${Math.floor(Math.random() * 1000)}`;
+    loader.data.mobs[id] = {
+      name: tpl.name,
+      level,
+      hp: 10 + level * 10,
+      damage: Math.max(1, Math.floor(level * 1.5)),
+      dropTable: (tpl.loot_table || []).map((lid) => ({ id: lid, weight: 1 }))
+    };
+    this.zones[zoneId].mobs[id] = { tpl };
+    loader.data.locations[zoneId].spawns.push(id);
+    ws.send('mob_spawn', { zoneId, mobId: id, mob: loader.data.mobs[id] });
+  },
+
+  killMob(zoneId, mobId) {
+    const zone = this.zones[zoneId];
+    if (!zone || !zone.mobs[mobId]) return;
+    const tpl = zone.mobs[mobId].tpl;
+    delete zone.mobs[mobId];
+    const loc = loader.data.locations[zoneId];
+    if (loc) loc.spawns = loc.spawns.filter((id) => id !== mobId);
+    delete loader.data.mobs[mobId];
+    ws.send('mob_remove', { zoneId, mobId });
+    const delay = this._randRange(15, 30) * 1000;
+    setTimeout(() => {
+      this.spawnMob(zoneId, tpl);
+    }, delay);
+  },
+
+  getMobIds(zoneId) {
+    return Object.keys(this.zones[zoneId]?.mobs || {});
+  },
+
+  _randRange(min, max) {
+    return Math.floor(Math.random() * (max - min + 1)) + min;
   }
 };


### PR DESCRIPTION
## Summary
- introduce a `zones` mob manager in `worldState.js`
- load zone mobs once and share them across players
- respawn killed mobs after 15–30 seconds
- broadcast mob spawn and removal via the websocket stub
- update `main.js` to handle mob events and show consistent mobs for all players

## Testing
- `npm run build-map`
- `node --check main.js`
- `node --check worldState.js`


------
https://chatgpt.com/codex/tasks/task_e_688ac1947bd4832faa9de635dc6e6b9c