### PR TITLE
Fix HUD bars and restore crafting tab

### DIFF
--- a/index.html
+++ b/index.html
@@ -24,6 +24,11 @@
         <span id="player-hp-text" class="w-14 text-right"></span>
       </div>
       <div class="flex items-center gap-1">
+        <span class="text-xs">MP</span>
+        <div class="progress w-24"><div id="mp-fill" class="progress-fill bg-indigo-600"></div></div>
+        <span id="player-mp-text" class="w-14 text-right"></span>
+      </div>
+      <div class="flex items-center gap-1">
         <span class="text-xs">XP</span>
         <div class="progress w-24"><div id="xp-fill" class="progress-fill bg-blue-600"></div></div>
         <span id="player-xp-text" class="w-14 text-right"></span>
@@ -33,6 +38,7 @@
     <nav class="flex gap-2 text-sm">
       <button data-tab="tab-inventory" class="btn tab-btn">Inventory</button>
       <button data-tab="tab-quests" class="btn tab-btn">Quests</button>
+      <button data-tab="tab-craft" class="btn tab-btn">Crafting</button>
       <button data-panel="map" class="btn">Map</button>
       <a href="profile.html" class="btn">Settings</a>
     </nav>
@@ -90,6 +96,7 @@
       <div class="tabs flex gap-1 mb-2">
         <button data-tab="tab-inventory" class="btn tab-btn text-xs">Inventory</button>
         <button data-tab="tab-quests" class="btn tab-btn text-xs">Quests</button>
+        <button data-tab="tab-craft" class="btn tab-btn text-xs">Crafting</button>
         <button data-tab="tab-mob" class="btn tab-btn text-xs">Mob Info</button>
         <button data-tab="tab-lore" class="btn tab-btn text-xs">Lore</button>
       </div>
@@ -99,6 +106,9 @@
         </div>
         <div id="tab-quests" class="tab-panel hidden">
           <div id="quests" class="hud-box"></div>
+        </div>
+        <div id="tab-craft" class="tab-panel hidden">
+          <div id="craft-panel" class="hud-box"></div>
         </div>
         <div id="tab-mob" class="tab-panel hidden">
           <div id="dialogue" class="hud-box hidden"></div>

--- a/main.js
+++ b/main.js
@@ -303,6 +303,10 @@ function updateHUD() {
   if (hpText) hpText.textContent = `${p.hp}/${p.maxHp}`;
   const hpFill = document.getElementById('hp-fill');
   if (hpFill) hpFill.style.width = `${(p.hp / p.maxHp) * 100}%`;
+  const mpText = document.getElementById('player-mp-text');
+  if (mpText) mpText.textContent = `${p.mp}/${p.maxMp}`;
+  const mpFill = document.getElementById('mp-fill');
+  if (mpFill) mpFill.style.width = `${(p.mp / p.maxMp) * 100}%`;
   const xpText = document.getElementById('player-xp-text');
   if (xpText) xpText.textContent = p.xp || 0;
   const xpFill = document.getElementById('xp-fill');
@@ -310,6 +314,9 @@ function updateHUD() {
   const goldEl = document.getElementById('player-gold');
   if (goldEl)
     goldEl.textContent = `${p.coins.gold}g ${p.coins.silver}s ${p.coins.copper}c`;
+  const statusEl = document.getElementById('status');
+  if (statusEl)
+    statusEl.textContent = `HP: ${p.hp}/${p.maxHp}\u2003MP: ${p.mp}/${p.maxMp}\u2003XP: ${p.xp}`;
 }
 
 function updateLocationPanel() {
@@ -1516,8 +1523,8 @@ function showRecipes(prof) {
     });
 }
 
-function buildCraftPanel() {
-  const panel = document.getElementById('craft');
+function buildCraftPanel(target = 'craft') {
+  const panel = document.getElementById(target);
   panel.innerHTML = '<h2 class="text-lg mb-2">Crafting</h2>';
   const list = document.createElement('ul');
   Object.entries(loader.data.professions).forEach(([pid, prof]) => {
@@ -1708,7 +1715,9 @@ function bindUI() {
       document.querySelectorAll('.tab-btn').forEach((b) => b.classList.remove('active'));
       document.querySelectorAll('.tab-panel').forEach((p) => p.classList.add('hidden'));
       btn.classList.add('active');
-      document.getElementById(btn.dataset.tab).classList.remove('hidden');
+      const panel = document.getElementById(btn.dataset.tab);
+      panel.classList.remove('hidden');
+      if (btn.dataset.tab === 'tab-craft') buildCraftPanel('craft-panel');
     };
   });
   const firstTab = document.querySelector('.tab-btn');


### PR DESCRIPTION
## Summary
- display MP next to HP and XP in HUD
- update HUD to fill MP bar and status box
- add Crafting tab with panel
- render crafting interface when the tab is clicked

## Testing
- `npm run build-map`
- `npm run clear-events`

------
https://chatgpt.com/codex/tasks/task_e_688ac6693b5c832f9121d01ae8553b66