### PR TITLE
UI overhaul with chat customization

### DIFF
--- a/index.html
+++ b/index.html
@@ -33,6 +33,7 @@
     <nav class="flex gap-2 text-sm">
       <button data-tab="tab-inventory" class="btn tab-btn">Inventory</button>
       <button data-tab="tab-quests" class="btn tab-btn">Quests</button>
+      <button data-tab="tab-auction" class="btn tab-btn">Auction</button>
       <button data-panel="map" class="btn">Map</button>
       <a href="profile.html" class="btn">Settings</a>
     </nav>
@@ -76,6 +77,12 @@
 
     <div class="flex flex-col gap-2 overflow-hidden">
       <section id="log" class="grow bg-slate-800 p-3 rounded overflow-y-auto"></section>
+      <div id="chat-combat-container" class="grid grid-cols-1 md:grid-cols-2 gap-2">
+        <div id="chat-window" class="relative bg-slate-800 p-2 rounded h-40 overflow-y-auto">
+          <button id="open-chat-settings" class="btn absolute top-1 right-1 text-xs">⚙</button>
+        </div>
+        <div id="combat-log-window" class="bg-slate-800 p-2 rounded h-40 overflow-y-auto"></div>
+      </div>
       <footer class="shrink-0 p-2 bg-slate-800 flex gap-2">
         <input id="cmd" class="flex-grow bg-slate-700 p-2 rounded" placeholder="Type command or /help">
         <button id="send" class="btn">Send</button>
@@ -90,6 +97,7 @@
       <div class="tabs flex gap-1 mb-2">
         <button data-tab="tab-inventory" class="btn tab-btn text-xs">Inventory</button>
         <button data-tab="tab-quests" class="btn tab-btn text-xs">Quests</button>
+        <button data-tab="tab-auction" class="btn tab-btn text-xs">Auction</button>
         <button data-tab="tab-mob" class="btn tab-btn text-xs">Mob Info</button>
         <button data-tab="tab-lore" class="btn tab-btn text-xs">Lore</button>
       </div>
@@ -99,6 +107,9 @@
         </div>
         <div id="tab-quests" class="tab-panel hidden">
           <div id="quests" class="hud-box"></div>
+        </div>
+        <div id="tab-auction" class="tab-panel hidden">
+          <div id="auction-house" class="hud-box">Auction House coming soon...</div>
         </div>
         <div id="tab-mob" class="tab-panel hidden">
           <div id="dialogue" class="hud-box hidden"></div>
@@ -114,6 +125,16 @@
     <div id="craft" class="panel hidden bg-slate-800 p-4 rounded mb-4"></div>
     <div id="codex" class="panel hidden bg-slate-800 p-4 rounded mb-4"></div>
     <div id="loot" class="panel hidden bg-slate-800 p-4 rounded mb-4"></div>
+    <div id="chat-settings" class="panel hidden bg-slate-800 p-4 rounded mb-4">
+      <h2 class="text-lg mb-2">Chat Settings</h2>
+      <form id="chat-settings-form" class="space-y-2">
+        <label class="flex items-center gap-2"><input type="checkbox" id="show-world"> Show World <input type="color" id="color-world" value="#00ffff" class="ml-auto"></label>
+        <label class="flex items-center gap-2"><input type="checkbox" id="show-guild"> Show Guild <input type="color" id="color-guild" value="#00ff00" class="ml-auto"></label>
+        <label class="flex items-center gap-2"><input type="checkbox" id="show-party"> Show Party <input type="color" id="color-party" value="#ff00ff" class="ml-auto"></label>
+        <label class="flex items-center gap-2"><input type="checkbox" id="show-private"> Show Private <input type="color" id="color-private" value="#ffffff" class="ml-auto"></label>
+        <div class="text-center pt-2"><button class="btn" type="submit">Save</button></div>
+      </form>
+    </div>
     <div class="text-center">
       <button id="close-overlay" class="btn">Close</button>
     </div>
@@ -128,8 +149,7 @@
   <!-- Hotbar for abilities -->
   <div id="hotbar" class="shrink-0 p-2 bg-slate-800 flex gap-1 overflow-x-auto"></div>
 
-  <!-- Chat dock -->
-  <div id="chat-panel" class="shrink-0 bg-slate-800 p-2 h-32 overflow-y-auto"></div>
+
 
   <!-- Movement controls -->
   <div id="move-controls" class="shrink-0 p-2 bg-slate-800 flex gap-1 justify-center"></div>

--- a/main.js
+++ b/main.js
@@ -348,6 +348,23 @@ function buildMoveControls(loc) {
   });
 }
 
+function loadChatSettings() {
+  const data = localStorage.getItem('chatSettings');
+  if (data) return JSON.parse(data);
+  return {
+    world: { show: true, color: '#00ffff' },
+    guild: { show: true, color: '#00ff00' },
+    party: { show: true, color: '#ff00ff' },
+    private: { show: true, color: '#ffffff' }
+  };
+}
+
+function saveChatSettings() {
+  localStorage.setItem('chatSettings', JSON.stringify(chatSettings));
+}
+
+let chatSettings = loadChatSettings();
+
 function addLog(txt) {
   const div = document.createElement('div');
   div.textContent = txt;
@@ -362,10 +379,14 @@ function addHtmlLog(html) {
   div.scrollIntoView();
 }
 
-function addChat(txt) {
+function addChat(txt, channel) {
+  const settings = chatSettings[channel] || { show: true, color: '#ffffff' };
+  if (!settings.show) return;
   const div = document.createElement('div');
   div.textContent = txt;
-  document.getElementById('chat-panel').append(div);
+  div.style.color = settings.color;
+  document.getElementById('chat-window').append(div);
+  div.scrollIntoView();
 }
 
 function showLoot(loot) {
@@ -681,8 +702,16 @@ function addCombatLog(txt) {
   const div = document.createElement('div');
   div.textContent = txt;
   const log = document.getElementById('combat-log');
-  log.append(div);
-  log.scrollTop = log.scrollHeight;
+  if (log) {
+    log.append(div);
+    log.scrollTop = log.scrollHeight;
+  }
+  const main = document.getElementById('combat-log-window');
+  if (main) {
+    const clone = div.cloneNode(true);
+    main.append(clone);
+    main.scrollTop = main.scrollHeight;
+  }
 }
 
 function updateCombatUI() {
@@ -1682,7 +1711,7 @@ function bindUI() {
   });
   ws.on('chat', (m) => {
     addLog(`[${m.channel}] ${m.msg}`);
-    addChat(`[${m.channel}] ${m.msg}`);
+    addChat(`[${m.channel}] ${m.msg}`, m.channel);
   });
   ws.on('mob_spawn', ({ zoneId, mobId, mob }) => {
     loader.data.mobs[mobId] = mob;
@@ -1711,6 +1740,30 @@ function bindUI() {
       document.getElementById(btn.dataset.tab).classList.remove('hidden');
     };
   });
+  document.getElementById('open-chat-settings').onclick = () => {
+    document.getElementById('show-world').checked = chatSettings.world.show;
+    document.getElementById('show-guild').checked = chatSettings.guild.show;
+    document.getElementById('show-party').checked = chatSettings.party.show;
+    document.getElementById('show-private').checked = chatSettings.private.show;
+    document.getElementById('color-world').value = chatSettings.world.color;
+    document.getElementById('color-guild').value = chatSettings.guild.color;
+    document.getElementById('color-party').value = chatSettings.party.color;
+    document.getElementById('color-private').value = chatSettings.private.color;
+    showPanel('chat-settings');
+  };
+  document.getElementById('chat-settings-form').onsubmit = (e) => {
+    e.preventDefault();
+    chatSettings.world.show = document.getElementById('show-world').checked;
+    chatSettings.guild.show = document.getElementById('show-guild').checked;
+    chatSettings.party.show = document.getElementById('show-party').checked;
+    chatSettings.private.show = document.getElementById('show-private').checked;
+    chatSettings.world.color = document.getElementById('color-world').value;
+    chatSettings.guild.color = document.getElementById('color-guild').value;
+    chatSettings.party.color = document.getElementById('color-party').value;
+    chatSettings.private.color = document.getElementById('color-private').value;
+    saveChatSettings();
+    document.getElementById('overlay').classList.add('hidden');
+  };
   const firstTab = document.querySelector('.tab-btn');
   if (firstTab) firstTab.click();
   document.getElementById('close-overlay').onclick = () => {

--- a/style.css
+++ b/style.css
@@ -4,7 +4,8 @@
 
 /* Custom tweaks */
 body {
-  font-family: ui-monospace, monospace;
+  font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+  background: linear-gradient(to bottom, #1e293b, #0f172a);
 }
 
 /* HUD boxes styling */
@@ -14,7 +15,7 @@ body {
 
 /* Button styling */
 .btn {
-  @apply px-3 py-1 bg-indigo-600 hover:bg-indigo-500 rounded;
+  @apply px-3 py-1 bg-indigo-500 hover:bg-indigo-400 rounded text-sm;
 }
 
 /* NPC list buttons */
@@ -62,4 +63,10 @@ body {
 }
 .tab-panel {
   @apply w-full;
+}
+
+/* Chat & combat windows */
+#chat-window,
+#combat-log-window {
+  @apply text-sm bg-slate-800 rounded p-2 h-40 overflow-y-auto;
 }


### PR DESCRIPTION
## Summary
- add Auction tab in UI
- redesign main area with chat & combat windows
- allow customizable chat filters and colors
- add simple chat settings panel
- style tweaks with gradient background

## Testing
- `npx eslint .` *(fails: numerous lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_688ac7906ea4832fb31a6862f733058b