### PR TITLE
Add low-level starter mobs

### DIFF
--- a/data/mobs/ashmoor_fields.json
+++ b/data/mobs/ashmoor_fields.json
@@ -20,6 +20,19 @@
       ]
     },
     {
+      "id": "timid_rabbit",
+      "name": "Timid Rabbit",
+      "type": "beast",
+      "level_range": [
+        1,
+        1
+      ],
+      "spawn_rate": 0.35,
+      "loot_table": [
+        "rabbit_pelt"
+      ]
+    },
+    {
       "id": "ashmoor_snake",
       "name": "Ashmoor Snake",
       "type": "beast",

--- a/data/mobs/emerald_copse.json
+++ b/data/mobs/emerald_copse.json
@@ -20,6 +20,19 @@
       ]
     },
     {
+      "id": "grazing_fawn",
+      "name": "Grazing Fawn",
+      "type": "beast",
+      "level_range": [
+        1,
+        1
+      ],
+      "spawn_rate": 0.35,
+      "loot_table": [
+        "scrap_meat"
+      ]
+    },
+    {
       "id": "wandering_sprout",
       "name": "Wandering Sprout",
       "type": "plant",

--- a/data/mobs/scorched_flats.json
+++ b/data/mobs/scorched_flats.json
@@ -19,6 +19,19 @@
       ]
     },
     {
+      "id": "charred_scarab",
+      "name": "Charred Scarab",
+      "type": "insect",
+      "level_range": [
+        1,
+        1
+      ],
+      "spawn_rate": 0.35,
+      "loot_table": [
+        "scarab_shell"
+      ]
+    },
+    {
       "id": "flame_beetle",
       "name": "Flame Beetle",
       "type": "insect",

--- a/data/mobs/worldrend_citadel.json
+++ b/data/mobs/worldrend_citadel.json
@@ -1,7 +1,7 @@
 {
   "zone": "worldrend_citadel",
   "recommended_level_range": [
-    60,
+    59,
     60
   ],
   "mobs": [

--- a/data/zones/vokarn/worldrend_citadel.json
+++ b/data/zones/vokarn/worldrend_citadel.json
@@ -3,7 +3,7 @@
   "name": "Worldrend Citadel",
   "description": "This is a placeholder description for Worldrend Citadel.",
   "level_range": [
-    60,
+    59,
     65
   ],
   "type": "pvp/endgame",


### PR DESCRIPTION
## Summary
- add level 1 mobs to starter zones (Emerald Copse, Ashmoor Fields, Scorched Flats)
- extend level range to include level 59 in endgame zone Worldrend Citadel

## Testing
- `npm run build-map`

------
https://chatgpt.com/codex/tasks/task_e_688ac9ac686c832fba15d04a1cae8d40