### PR TITLE
Implement player death penalties

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -12,6 +12,7 @@ export default [
         fetch: 'readonly',
         location: 'readonly',
         setInterval: 'readonly',
+        setTimeout: 'readonly',
         clearInterval: 'readonly',
         localStorage: 'readonly',
         console: 'readonly'

--- a/main.js
+++ b/main.js
@@ -44,6 +44,7 @@ function loadCharacter() {
   p.guild ||= null;
   p.reputation ||= { luminara: 0, umbra: 0, neutral: 0 };
   p.xp ||= 0;
+  p.homeLocation ||= p.location;
   p.achievements ||= { unlocked: [], titles: [], title: '', playTime: 0 };
   return p;
 }
@@ -747,8 +748,23 @@ function endCombat(win) {
     checkQuestProgress('kill', mob.id);
   } else {
     addLog('You have been slain!');
+    handlePlayerDeath();
   }
   updateHUD();
+}
+
+function handlePlayerDeath() {
+  const lvl = getPlayerLevel();
+  const loss = Math.floor(lvl * 20);
+  if (loss > 0) {
+    game.player.xp = Math.max(0, game.player.xp - loss);
+    addLog(`You lose ${loss} XP.`);
+  }
+  game.player.hp = game.player.maxHp;
+  game.player.mp = game.player.maxMp;
+  const home = game.player.homeLocation || game.player.location;
+  worldState.updatePlayer(game.player.name, { location: home });
+  enterRoom(home);
 }
 
 function enemyAttack() {
@@ -1921,6 +1937,7 @@ function showCreateForm() {
       mp: stats.spi * 4,
       maxMp: stats.spi * 4,
       location: loader.data.races[race].startLocation,
+      homeLocation: loader.data.races[race].startLocation,
       inventory: ['rusty_sword', 'healing_potion'],
       equipped: { weapon: 'rusty_sword' },
       gearTypes: clsDef.gear || [],


### PR DESCRIPTION
## Summary
- preserve starting location as a `homeLocation`
- respawn at `homeLocation` on death and lose XP
- note environment global for `setTimeout`

## Testing
- `npm install`
- `npx eslint main.js events.js worldState.js playerStats.js generateZonePlaceholders.js data/loader.js`

------
https://chatgpt.com/codex/tasks/task_e_688aca0a8944832f81f7377d55fb5bb4