### PR TITLE
Fix invalid zone exits and improve movement

### DIFF
--- a/data/world.json
+++ b/data/world.json
@@ -14,7 +14,7 @@
           "name": "Ironvale Hold",
           "type": "city",
           "level_range": [0, 0],
-          "exits": { "south": "ashmoor_fields", "dock": "boat_ironvale_sandspire" }
+          "exits": { "south": "ashmoor_fields", "dock": "sandspire" }
         },
         {
           "id": "ashmoor_fields",
@@ -89,7 +89,7 @@
           "name": "Sandspire",
           "type": "city",
           "level_range": [0, 0],
-          "exits": { "north": "scorched_flats", "dock": "boat_ironvale_sandspire", "teleport_pad": "tele_sandspire_sylvaran" }
+          "exits": { "north": "scorched_flats", "dock": "ironvale_hold", "teleport_pad": "sylvaran_grove" }
         },
         {
           "id": "scorched_flats",
@@ -157,7 +157,7 @@
           "name": "Sylvaran Grove",
           "type": "city",
           "level_range": [0, 0],
-          "exits": { "south": "emerald_copse", "portal": "tele_sandspire_sylvaran", "ancient_tree": "tree_sylvaran_stormveil" }
+          "exits": { "south": "emerald_copse", "portal": "sandspire", "ancient_tree": "stormveil_bastion" }
         },
         {
           "id": "emerald_copse",
@@ -223,7 +223,7 @@
           "name": "Stormveil Bastion",
           "type": "city",
           "level_range": [0, 0],
-          "exits": { "south": "ashenflow_tundra", "tree_portal": "tree_sylvaran_stormveil" }
+          "exits": { "south": "ashenflow_tundra", "tree_portal": "sylvaran_grove" }
         },
         {
           "id": "ashenflow_tundra",
@@ -258,7 +258,7 @@
           "name": "Dreadhold Depths",
           "type": "raid",
           "level_range": [50, 60],
-          "exits": { "up": "burnscar_chasm", "portal": "raid_gate_every_capital" }
+          "exits": { "up": "burnscar_chasm", "portal": "stormveil_bastion" }
         },
         {
           "id": "worldrend_citadel",

--- a/data/zones/keldrith/sylvaran_grove.json
+++ b/data/zones/keldrith/sylvaran_grove.json
@@ -9,8 +9,8 @@
   "type": "city",
   "exits": {
     "south": "emerald_copse",
-    "portal": "tele_sandspire_sylvaran",
-    "ancient_tree": "tree_sylvaran_stormveil"
+    "portal": "sandspire",
+    "ancient_tree": "stormveil_bastion"
   },
   "mobs": [
     {

--- a/data/zones/shadowfen.json
+++ b/data/zones/shadowfen.json
@@ -6,7 +6,6 @@
       "faction": "umbra",
       "description": "A dark encampment surrounded by murky waters where warriors of Umbra sharpen their blades.",
       "exits": [
-        "n",
         "e"
       ],
       "links": {

--- a/data/zones/veldara/ironvale_hold.json
+++ b/data/zones/veldara/ironvale_hold.json
@@ -9,7 +9,7 @@
   "type": "city",
   "exits": {
     "south": "ashmoor_fields",
-    "dock": "boat_ironvale_sandspire"
+    "dock": "sandspire"
   },
   "mobs": [
     {

--- a/data/zones/vokarn/dreadhold_depths.json
+++ b/data/zones/vokarn/dreadhold_depths.json
@@ -9,7 +9,7 @@
   "type": "raid",
   "exits": {
     "up": "burnscar_chasm",
-    "portal": "raid_gate_every_capital"
+    "portal": "stormveil_bastion"
   },
   "mobs": [
     {

--- a/data/zones/vokarn/stormveil_bastion.json
+++ b/data/zones/vokarn/stormveil_bastion.json
@@ -9,7 +9,7 @@
   "type": "city",
   "exits": {
     "south": "ashenflow_tundra",
-    "tree_portal": "tree_sylvaran_stormveil"
+    "tree_portal": "sylvaran_grove"
   },
   "mobs": [
     {

--- a/data/zones/zhurakai/sandspire.json
+++ b/data/zones/zhurakai/sandspire.json
@@ -9,8 +9,8 @@
   "type": "city",
   "exits": {
     "north": "scorched_flats",
-    "dock": "boat_ironvale_sandspire",
-    "teleport_pad": "tele_sandspire_sylvaran"
+    "dock": "ironvale_hold",
+    "teleport_pad": "sylvaran_grove"
   },
   "mobs": [
     {

--- a/main.js
+++ b/main.js
@@ -534,8 +534,13 @@ async function enterRoom(id) {
 
 async function move(dir) {
   console.log('Move', dir);
-  const dest = loader.data.locations[game.player.location].links[dir];
-  if (dest) await enterRoom(dest);
+  const cur = loader.data.locations[game.player.location];
+  const dest = cur?.links?.[dir];
+  if (!dest) {
+    addLog("You can't go that way.");
+    return;
+  }
+  await enterRoom(dest);
 }
 
 


### PR DESCRIPTION
## Summary
- ensure exits in zone JSON files point to real zone IDs
- sync world.json with updated exits
- guard player movement in `move` to stop invalid exits

## Testing
- `npm install`
- `npx eslint .` *(fails: cannot find package '@eslint/js' & many lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_688acd99b854832fa76ebb699dc1fcf2