### PR TITLE
Improve combat targeting UI

### DIFF
--- a/index.html
+++ b/index.html
@@ -102,9 +102,7 @@
         <div class="font-bold mb-1">Party</div>
         <div id="party-list">—</div>
       </div>
-      <div id="target" class="hud-box">Target: —</div>
       <div id="combat-info" class="hud-box hidden"></div>
-      <div id="party" class="hud-box">Party: —</div>
       <div id="currency" class="hud-box">Coins: 0g 0s 0c</div>
       <div class="tabs flex gap-1 mb-2">
         <button data-tab="tab-inventory" class="btn tab-btn text-xs">Inventory</button>

--- a/main.js
+++ b/main.js
@@ -124,6 +124,8 @@ function selectTarget(type, id, btn, group = null) {
   document.getElementById('dialogue').classList.add('hidden');
   updateHUD();
   updateTargetPanel();
+  if (game.target) addLog(`Targeting ${game.target.name}.`);
+  else addLog('Target cleared.');
 }
 function randomRarity(level) {
   const roll = Math.random() * 100;
@@ -746,30 +748,27 @@ function updatePartyPanel() {
 }
 
 function updateTargetPanel() {
+  const panel = document.getElementById('target');
   const nameEl = document.getElementById('target-name');
-  if (!nameEl) return;
-  if (game.target) {
-    const hp = game.target.hp != null ? ` (${game.target.hp} HP)` : '';
-    nameEl.textContent = `${game.target.name}${hp}`;
+  if (!panel) return;
+  const t = game.target;
+  panel.innerHTML = '';
+  if (!t) {
+    if (nameEl) {
+      nameEl.textContent = '—';
+      nameEl.onclick = null;
+    }
+    panel.textContent = 'Target: —';
+    return;
+  }
+  if (nameEl) {
+    const hpText = t.hp != null ? ` (${t.hp} HP)` : '';
+    nameEl.textContent = `${t.name}${hpText}`;
     nameEl.onclick = () => {
       const tgt = game.target;
       const targetOfTarget = game.inCombat ? game.player.name : 'nobody';
       addLog(`${tgt.name} is targeting ${targetOfTarget}.`);
     };
-  } else {
-    nameEl.textContent = '—';
-    nameEl.onclick = null;
-  }
-}
-
-function updateTargetPanel() {
-  const panel = document.getElementById('target');
-  if (!panel) return;
-  const t = game.target;
-  panel.innerHTML = '';
-  if (!t) {
-    panel.textContent = 'Target: —';
-    return;
   }
   const header = document.createElement('div');
   header.className = 'font-bold mb-1';
@@ -892,6 +891,7 @@ function endCombat(win) {
   updateHUD();
   updateCombatUI();
   updateTargetPanel();
+  addCombatLog('Combat ended.');
 }
 
 function handlePlayerDeath() {
@@ -967,6 +967,8 @@ function startCombat(targetId, type = 'mob') {
   game.target = { ...data, id: targetId, type };
   game.inCombat = true;
   document.getElementById('combat-log').innerHTML = '';
+  addCombatLog(`Combat started with ${game.target.name}.`);
+  addLog(`You engage ${game.target.name}.`);
   if (type === 'mob') {
     loader.data.mobs[targetId].inCombat = true;
     const loc = loader.data.locations[game.player.location];


### PR DESCRIPTION
## Summary
- ensure only one target panel exists in the layout
- consolidate `updateTargetPanel` logic
- log when targets are selected or combat begins/ends

## Testing
- `npx eslint .` *(fails: 'useAbility' is defined but never used, many errors in scripts/d3.min.js)*

------
https://chatgpt.com/codex/tasks/task_e_688ace22c62c832f98515741916fe808