### PR TITLE
Reworked layout using Tailwind 3-panel design

### DIFF
--- a/index.html
+++ b/index.html
@@ -36,12 +36,11 @@
       <span id="player-gold"></span>
     </div>
     <nav class="flex gap-2 text-sm">
-      <button data-tab="tab-inventory" class="btn tab-btn">Inventory</button>
-      <button data-tab="tab-quests" class="btn tab-btn">Quests</button>
-      <button data-tab="tab-auction" class="btn tab-btn">Auction</button>
-      <button data-tab="tab-craft" class="btn tab-btn">Crafting</button>
-      <button data-panel="map" class="btn">Map</button>
-      <a href="profile.html" class="btn">Settings</a>
+      <button data-panel="map" class="btn">World Map</button>
+      <button data-panel="zone-info" class="btn">Zone Info</button>
+      <button data-panel="character" class="btn">Character</button>
+      <button data-panel="guild" class="btn">Guild</button>
+      <button data-panel="auction" class="btn">Auction House</button>
     </nav>
   </header>
 
@@ -58,21 +57,9 @@
         <div id="location-name" class="font-bold mb-1">Location</div>
         <div id="location-exits" class="flex flex-wrap gap-1"></div>
       </div>
-      <div id="players-box" class="hud-box">
-        <div class="font-bold mb-1">Nearby Players</div>
-        <div id="player-list" class="flex flex-wrap gap-1"></div>
-      </div>
       <div id="npcs-box" class="hud-box">
         <div class="font-bold mb-1">Nearby NPCs</div>
         <div id="npc-list" class="flex flex-col gap-1"></div>
-      </div>
-      <div id="mobs-box" class="hud-box">
-        <div class="font-bold mb-1">Nearby Mobs</div>
-        <div id="mob-list" class="flex flex-wrap gap-1"></div>
-      </div>
-      <div id="nodes-box" class="hud-box">
-        <div class="font-bold mb-1">Nearby Objects</div>
-        <div id="node-list" class="flex flex-wrap gap-1"></div>
       </div>
       <div id="actions-box" class="hud-box">
         <div class="font-bold mb-1">Actions</div>
@@ -81,18 +68,21 @@
       <div id="minimap" class="hud-box h-40"></div>
     </aside>
 
-    <div class="flex flex-col gap-2 overflow-hidden">
-      <section id="log" class="grow bg-slate-800 p-3 rounded overflow-y-auto"></section>
-      <div id="chat-combat-container" class="grid grid-cols-1 md:grid-cols-2 gap-2">
+    <div id="center-panel" class="flex flex-col h-full overflow-hidden">
+      <div id="logs" class="flex flex-col overflow-y-auto grow">
+        <section id="log" class="bg-slate-800 p-3 rounded mb-2 grow overflow-y-auto"></section>
+        <div id="combat-log-window" class="bg-slate-800 p-2 rounded h-40 overflow-y-auto"></div>
+      </div>
+      <div id="drag-bar" class="h-2 bg-slate-700 cursor-row-resize"></div>
+      <div id="chat-section" class="flex flex-col">
         <div id="chat-window" class="relative bg-slate-800 p-2 rounded h-40 overflow-y-auto">
           <button id="open-chat-settings" class="btn absolute top-1 right-1 text-xs">⚙</button>
         </div>
-        <div id="combat-log-window" class="bg-slate-800 p-2 rounded h-40 overflow-y-auto"></div>
+        <footer class="shrink-0 p-2 bg-slate-800 flex gap-2">
+          <input id="cmd" class="flex-grow bg-slate-700 p-2 rounded" placeholder="Type command or /help">
+          <button id="send" class="btn">Send</button>
+        </footer>
       </div>
-      <footer class="shrink-0 p-2 bg-slate-800 flex gap-2">
-        <input id="cmd" class="flex-grow bg-slate-700 p-2 rounded" placeholder="Type command or /help">
-        <button id="send" class="btn">Send</button>
-      </footer>
     </div>
 
     <aside id="right-panel" class="bg-slate-800 p-3 rounded flex flex-col gap-2 overflow-y-auto">
@@ -102,9 +92,7 @@
         <div class="font-bold mb-1">Party</div>
         <div id="party-list">—</div>
       </div>
-      <div id="target" class="hud-box">Target: —</div>
       <div id="combat-info" class="hud-box hidden"></div>
-      <div id="party" class="hud-box">Party: —</div>
       <div id="currency" class="hud-box">Coins: 0g 0s 0c</div>
       <div class="tabs flex gap-1 mb-2">
         <button data-tab="tab-inventory" class="btn tab-btn text-xs">Inventory</button>
@@ -136,6 +124,10 @@
   <!-- Overlay panels -->
   <div id="overlay" class="hidden fixed inset-0 bg-black/70 p-4 overflow-auto">
     <div id="map" class="panel hidden bg-slate-800 p-4 rounded mb-4"></div>
+    <div id="zone-info" class="panel hidden bg-slate-800 p-4 rounded mb-4"></div>
+    <div id="character" class="panel hidden bg-slate-800 p-4 rounded mb-4"></div>
+    <div id="guild" class="panel hidden bg-slate-800 p-4 rounded mb-4"></div>
+    <div id="auction" class="panel hidden bg-slate-800 p-4 rounded mb-4"></div>
     <div id="graph" class="panel hidden bg-slate-800 p-4 rounded mb-4"></div>
     <div id="craft" class="panel hidden bg-slate-800 p-4 rounded mb-4"></div>
     <div id="codex" class="panel hidden bg-slate-800 p-4 rounded mb-4"></div>

--- a/main.js
+++ b/main.js
@@ -746,23 +746,6 @@ function updatePartyPanel() {
 }
 
 function updateTargetPanel() {
-  const nameEl = document.getElementById('target-name');
-  if (!nameEl) return;
-  if (game.target) {
-    const hp = game.target.hp != null ? ` (${game.target.hp} HP)` : '';
-    nameEl.textContent = `${game.target.name}${hp}`;
-    nameEl.onclick = () => {
-      const tgt = game.target;
-      const targetOfTarget = game.inCombat ? game.player.name : 'nobody';
-      addLog(`${tgt.name} is targeting ${targetOfTarget}.`);
-    };
-  } else {
-    nameEl.textContent = '—';
-    nameEl.onclick = null;
-  }
-}
-
-function updateTargetPanel() {
   const panel = document.getElementById('target');
   if (!panel) return;
   const t = game.target;
@@ -1082,6 +1065,7 @@ function buildNPCList(npcs) {
 
 function buildNodeList(nodes) {
   const list = document.getElementById('node-list');
+  if (!list) return;
   list.innerHTML = '';
   (nodes || []).forEach((id) => {
     const node = loader.get('nodes', id);
@@ -1096,6 +1080,7 @@ function buildNodeList(nodes) {
 
 function buildMobList(mobs, groups = []) {
   const list = document.getElementById('mob-list');
+  if (!list) return;
   list.innerHTML = '';
   const groupedIds = new Set(groups.flat());
   groups.forEach((grp) => {
@@ -1918,6 +1903,29 @@ function bindUI() {
   document.getElementById('close-overlay').onclick = () => {
     document.getElementById('overlay').classList.add('hidden');
   };
+  const dragBar = document.getElementById('drag-bar');
+  if (dragBar) {
+    let dragging = false;
+    const logs = document.getElementById('logs');
+    const chat = document.getElementById('chat-section');
+    dragBar.addEventListener('mousedown', () => {
+      dragging = true;
+    });
+    document.addEventListener('mousemove', (e) => {
+      if (!dragging) return;
+      const rect = document
+        .getElementById('center-panel')
+        .getBoundingClientRect();
+      const ratio = (e.clientY - rect.top) / rect.height;
+      if (ratio > 0.1 && ratio < 0.9) {
+        logs.style.flexBasis = `${ratio * 100}%`;
+        chat.style.flexBasis = `${(1 - ratio) * 100}%`;
+      }
+    });
+    document.addEventListener('mouseup', () => {
+      dragging = false;
+    });
+  }
   document.getElementById('move-controls').addEventListener('click', (e) => {
     const dir = e.target.dataset.dir;
     if (dir) move(dir);

--- a/style.css
+++ b/style.css
@@ -81,3 +81,7 @@ body {
 #combat-log-window {
   @apply text-sm bg-slate-800 rounded p-2 h-40 overflow-y-auto;
 }
+
+#drag-bar {
+  @apply h-2 bg-slate-600 cursor-row-resize;
+}


### PR DESCRIPTION
## Summary
- create a draggable center panel for logs and chat
- clean up duplicate widgets in right panel
- slim left panel to zone info and NPCs only
- add overlay panels for world map, zone info, character, guild and auction house
- minor style tweaks

## Testing
- `npx eslint .` *(fails: numerous errors in dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_688acfc529c8832f860b58a529ebfaac