### PR TITLE
Add Diablo II abilities with combat selection

### DIFF
--- a/data/abilities.json
+++ b/data/abilities.json
@@ -1,0 +1,26 @@
+{
+  "cleave": {
+    "name": "Cleave",
+    "level": 1,
+    "damage": 5,
+    "description": "A sweeping melee strike hitting multiple foes."
+  },
+  "bash": {
+    "name": "Bash",
+    "level": 1,
+    "damage": 4,
+    "description": "A powerful strike that can stagger the target."
+  },
+  "firebolt": {
+    "name": "Firebolt",
+    "level": 1,
+    "damage": 6,
+    "description": "Hurl a small bolt of fire at the enemy."
+  },
+  "ice_shard": {
+    "name": "Ice Shard",
+    "level": 1,
+    "damage": 5,
+    "description": "Launch a shard of ice that chills the enemy."
+  }
+}

--- a/data/classes.json
+++ b/data/classes.json
@@ -118,5 +118,21 @@
       "40": ["song_of_valor_3", "lullaby_3"],
       "60": ["power_chord_2"]
     }
+  },
+  "barbarian": {
+    "name": "Barbarian",
+    "stats": {"str": 9, "dex": 6, "int": 3, "wis": 3, "spi": 4, "vit": 8},
+    "gear": ["axe", "mace", "twohand", "leather"],
+    "abilities": {
+      "1": ["cleave", "bash"]
+    }
+  },
+  "sorceress": {
+    "name": "Sorceress",
+    "stats": {"str": 3, "dex": 5, "int": 9, "wis": 8, "spi": 7, "vit": 4},
+    "gear": ["staff", "wand", "cloth"],
+    "abilities": {
+      "1": ["firebolt", "ice_shard"]
+    }
   }
 }

--- a/data/loader.js
+++ b/data/loader.js
@@ -76,6 +76,11 @@ export const loader = {
         Object.assign(this.data.abilities, await fetchJson(`data/abilities/${f}.json`));
       })
     );
+    try {
+      Object.assign(this.data.abilities, await fetchJson('data/abilities.json'));
+    } catch (err) {
+      console.warn('Failed to load abilities.json', err);
+    }
 
     if (typeof localStorage !== 'undefined') {
       const savedGuilds = localStorage.getItem('guilds');

--- a/main.js
+++ b/main.js
@@ -838,14 +838,28 @@ function addCombatLog(txt) {
 
 function updateCombatUI() {
   const panel = document.getElementById('combat-info');
-  if (!panel) return;
+  const overlay = document.getElementById('combat-overlay');
+  if (!panel || !overlay) return;
   if (!game.inCombat) {
     panel.classList.add('hidden');
+    overlay.classList.add('hidden');
     return;
   }
   const enemy = game.target;
   panel.classList.remove('hidden');
+  overlay.classList.remove('hidden');
   panel.textContent = `${enemy.name} HP: ${enemy.hp} | Your HP: ${game.player.hp}`;
+  document.getElementById('combat-enemy').textContent = enemy.name;
+  document.getElementById('combat-stats').textContent = `Enemy HP: ${enemy.hp} | Your HP: ${game.player.hp}`;
+  const wrap = document.getElementById('combat-buttons');
+  wrap.innerHTML = '';
+  getAvailableAbilities().forEach((id) => {
+    const btn = document.createElement('button');
+    btn.className = 'btn text-xs';
+    btn.textContent = loader.data.abilities[id]?.name || id;
+    btn.onclick = () => useAbility(id);
+    wrap.append(btn);
+  });
 }
 
 function endCombat(win) {


### PR DESCRIPTION
## Summary
- create `data/abilities.json` with basic skills for Barbarian and Sorceress
- register new classes in `classes.json`
- load `abilities.json` via `loader.js`
- display ability buttons in the combat overlay in `main.js`

## Testing
- `npm run build-map`

------
https://chatgpt.com/codex/tasks/task_e_688acff1b818832fbde94d43423cb7c9