### PR TITLE
Add level 1 mobs and adjust scaling

### DIFF
--- a/data/items.json
+++ b/data/items.json
@@ -144,5 +144,23 @@
     "damage": 4,
     "slot": "weapon",
     "description": "A crude mechanical glove packed with gears."
+  },
+  "rat_tail": {
+    "name": "Rat Tail",
+    "level": 1,
+    "rarity": "common",
+    "description": "A severed tail from a common field rat."
+  },
+  "small_hide": {
+    "name": "Small Hide",
+    "level": 1,
+    "rarity": "common",
+    "description": "Light hide usable for basic crafting."
+  },
+  "rabbit_pelt": {
+    "name": "Rabbit Pelt",
+    "level": 1,
+    "rarity": "common",
+    "description": "Soft pelt from a timid rabbit."
   }
 }

--- a/data/mobs.json
+++ b/data/mobs.json
@@ -46,5 +46,34 @@
       { "id": "bronze_sword", "weight": 80 },
       { "id": "rusty_dagger", "weight": 20 }
     ]
+  },
+  "field_rat": {
+    "name": "Field Rat",
+    "faction": "neutral",
+    "level": 1,
+    "hp": 12,
+    "damage": 1,
+    "str": 2,
+    "dex": 2,
+    "int": 1,
+    "description": "A small rodent scurrying in the fields.",
+    "dropTable": [
+      { "id": "rat_tail", "weight": 50 },
+      { "id": "small_hide", "weight": 30 }
+    ]
+  },
+  "timid_rabbit": {
+    "name": "Timid Rabbit",
+    "faction": "neutral",
+    "level": 1,
+    "hp": 10,
+    "damage": 1,
+    "str": 1,
+    "dex": 3,
+    "int": 1,
+    "description": "A nervous rabbit that flees danger.",
+    "dropTable": [
+      { "id": "rabbit_pelt", "weight": 50 }
+    ]
   }
 }

--- a/main.js
+++ b/main.js
@@ -653,11 +653,17 @@ async function loadZoneMobs(zoneId) {
 function createZoneMob(tpl) {
   const level = randRange(tpl.level_range[0], tpl.level_range[1]);
   const id = `zone_${game.currentZone.id}_${tpl.id}_${Date.now()}_${rand(1000)}`;
+  let hp = 10 + level * 10;
+  let damage = Math.max(1, Math.floor(level * 1.5));
+  if (level === 1) {
+    hp = 12;
+    damage = 1;
+  }
   loader.data.mobs[id] = {
     name: tpl.name,
     level,
-    hp: 10 + level * 10,
-    damage: Math.max(1, Math.floor(level * 1.5)),
+    hp,
+    damage,
     dropTable: (tpl.loot_table || []).map((lid) => ({ id: lid, weight: 1 }))
   };
   return id;


### PR DESCRIPTION
## Summary
- introduce early game items (rat_tail, small_hide, rabbit_pelt)
- add field_rat and timid_rabbit mobs for level 1 players
- make createZoneMob easier for level 1 by lowering hp and damage

## Testing
- `python3` & `node` not available; could not run tests

------
https://chatgpt.com/codex/tasks/task_e_688acdbed2f0832fa706d6b9eeb45f08